### PR TITLE
safe_glob now excludes"hidden" files

### DIFF
--- a/zp-core/functions-basic.php
+++ b/zp-core/functions-basic.php
@@ -1423,6 +1423,8 @@ function getRequestURI() {
 /**
 * Provide an alternative to glob which does not return filenames with accented charactes in them
 *
+* NOTE: this function ignores "hidden" files whose name starts with a period!
+*
 * @param string $pattern the 'pattern' for matching files
 * @param bit $flags glob 'flags'
 */
@@ -1439,7 +1441,7 @@ function safe_glob($pattern, $flags=0) {
 	if (($dir=opendir($path))!==false) {
 		$glob=array();
 		while(($file=readdir($dir))!==false) {
-			if(@preg_match($match, $file) && $file!='.' && $file!='..') {
+			if(@preg_match($match, $file) && $file{0}!='.') {
 				if ((is_dir("$path/$file"))||(!($flags&GLOB_ONLYDIR))) {
 					if ($flags&GLOB_MARK) $file.='/';
 					$glob[]=$path_return.$file;

--- a/zp-core/version.php
+++ b/zp-core/version.php
@@ -1,4 +1,4 @@
 <?php // This file contains version info only and is automatically updated. DO NOT EDIT.
 define('ZENPHOTO_VERSION', '1.4.4-DEV');
-define('ZENPHOTO_RELEASE', 10983);
+define('ZENPHOTO_RELEASE', 10984);
 ?>


### PR DESCRIPTION
safe_glob() will filter out files whose name begins with a period. For
instance, Bluehost (simplescripts?)  seems to place a bunch of ._<file>
files in the folders of the Zenphoto install which, since Simplescripts
does not run setup, are left there.
