### PR TITLE
Require confirmation of security issues

### DIFF
--- a/zp-core/setup/setup-functions.php
+++ b/zp-core/setup/setup-functions.php
@@ -396,16 +396,19 @@ function setupLog($message, $anyway=false, $reset=false) {
 /*
  * updates database config parameters
  */
-function updateConfigItem($item, $value) {
+function updateConfigItem($item, $value, $quote=true) {
 	global $zp_cfg;
+	if ($quote) {
+		$value = '"'.$value.'"';
+	}
 	$i = strpos($zp_cfg, $item);
-	if ($i == false) {
-		$i = strpos($zp_cfg, '$conf[');
-		$zp_cfg = substr($zp_cfg, 0, $i)."\$conf['".$item."'] = '".$value."'; // added by setup\n".substr($zp_cfg,$i);
+	if ($i === false) {
+		$i = strpos($zp_cfg, '/** Do not edit below this line. **/');
+		$zp_cfg = substr($zp_cfg, 0, $i)."\$conf['".$item."'] = ".$value.";\n".substr($zp_cfg,$i);
 	} else {
 		$i = strpos($zp_cfg, '=', $i);
 		$j = strpos($zp_cfg, "\n", $i);
-		$zp_cfg = substr($zp_cfg, 0, $i) . '= \'' . str_replace('\'', '\\\'',$value) . '\';' . substr($zp_cfg, $j);
+		$zp_cfg = substr($zp_cfg, 0, $i) . '= ' . $value . ';' . substr($zp_cfg, $j);
 	}
 }
 
@@ -587,6 +590,12 @@ function close_site($nht) {
 		$nht = str_replace($match, ' '.substr($match,1), $nht);
 	}
 	return $nht;
+}
+
+function acknowledge($value) {
+	global $xsrftoken;
+	$link = WEBPATH.'/'.ZENFOLDER.'/setup/index.php?security_ack='.$value.'&amp;xsrfToken='.$xsrftoken;
+	return sprintf(gettext('Click <a href="%s">here</a> to acknowledge that you wish to ignore this issue. It will then become a warning.'),$link);
 }
 
 ?>

--- a/zp-core/version.php
+++ b/zp-core/version.php
@@ -1,4 +1,4 @@
 <?php // This file contains version info only and is automatically updated. DO NOT EDIT.
 define('ZENPHOTO_VERSION', '1.4.4-DEV');
-define('ZENPHOTO_RELEASE', 10984);
+define('ZENPHOTO_RELEASE', 10985);
 ?>

--- a/zp-core/zenphoto_cfg.txt
+++ b/zp-core/zenphoto_cfg.txt
@@ -61,7 +61,6 @@ $conf['album_folder_class'] = 'std';
 // Otherwise you should leave it at "http"
 // NOTE: If you change this on an already installed configuration you will also have
 // to change the gallery configuration server protocal option.
-$conf['server_protocol'] = "http";
 //
 ////////////////////////////////////////////////////////////////////////////////
 // Path Overrides
@@ -77,6 +76,7 @@ $conf['server_protocol'] = "http";
 
 ////////////////////////////////////////////////////////////////////////////////
 if (!defined('CHMOD_VALUE')) { define('CHMOD_VALUE',0755); }
+$conf['server_protocol'] = "http";
 /** Do not edit below this line. **/
 /**********************************/
 $_zp_conf_vars = $conf;


### PR DESCRIPTION
Setup now has the facility to require the user to acknowledge any
configuration issues that might impact his site security.

This is used now for REGISTER_GLOBALS and for DISPLAY_ERRORS PHP
settings. Thes will show as errors until the user acknowledges that he
is willing to live with the security weaknesses.
