### PR TITLE
revert pull #48

### DIFF
--- a/zp-core/admin-logs.php
+++ b/zp-core/admin-logs.php
@@ -171,7 +171,7 @@ echo "\n</head>";
 									?>
 									<tr>
 									<?php
-									$fields = explode("\t", $line);
+									$fields = explode("\t", trim($line));
 									foreach ($fields as $key=>$field) {
 										?>
 										<td>
@@ -200,7 +200,7 @@ echo "\n</head>";
 									<p>
 										<span class="nowrap">
 										<?php
-										echo str_replace(' ','&nbsp;',html_encode(strip_tags($line)));
+										echo str_replace(' ','&nbsp;',html_encode(strip_tags(trim($line))));
 										?>
 										</span>
 									</p>

--- a/zp-core/admin-options.php
+++ b/zp-core/admin-options.php
@@ -811,6 +811,7 @@ if ($subtab == 'general' && zp_loggedin(OPTIONS_RIGHTS)) {
 								$tags = explode("\n",$t);
 								$c = 0;
 								foreach($tags as $t) {
+									$t = trim($t);
 									if (!empty($t)) {
 										if ($c>0) {
 											echo '+';
@@ -1986,7 +1987,7 @@ if ($subtab == 'image' && zp_loggedin(OPTIONS_RIGHTS)) {
 					// ]]> -->
 				</script>
 				<div id="slider-workers"></div>
-				<input type="hidden" id="cache-workers" name="cacheManager_workers" value="<?php echo getOption('cacheManager_workers');?>" />
+				<input type="hidden" id="cache-workers" name="iproc_proc_limit" value="<?php echo getOption('iproc_proc_limit');?>" />
 			</td>
 			<td>
 			<?php printf(gettext('Cache processing worker limit: %s.'),'<span id="cache_processes">'.getOption('imageProcessorConcurrency').'</span>').

--- a/zp-core/functions-image.php
+++ b/zp-core/functions-image.php
@@ -149,6 +149,9 @@ function iptc_make_tag($rec, $data, $value) {
 function cacheImage($newfilename, $imgfile, $args, $allow_watermark=false, $theme, $album) {
 	global $_zp_gallery;
 	try {
+		$iMutex = new Mutex('i',getOption('imageProcessorConcurrency'));
+		$iMutex-> lock();
+
 		@list($size, $width, $height, $cw, $ch, $cx, $cy, $quality, $thumb, $crop, $thumbstandin, $passedWM, $adminrequest, $effects) = $args;
 		// Set the config variables for convenience.
 		$image_use_side = getOption('image_use_side');
@@ -472,7 +475,9 @@ function cacheImage($newfilename, $imgfile, $args, $allow_watermark=false, $them
 		@chmod($newfile, FILE_MOD);
 		zp_imageKill($newim);
 		zp_imageKill($im);
+		$iMutex -> unlock();
 	} catch (Exception $e) {
+		$iMutex -> unlock();
 		debugLog('cacheImage('.$newfilename.') exception: '.$e->getMessage());
 		imageError('404 Not Found', sprintf(gettext('cacheImage(%1$s) exception: %2$s'),$newfilename,$e->getMessage()), 'err-failimage.png');
 		return false;

--- a/zp-core/i.php
+++ b/zp-core/i.php
@@ -225,10 +225,7 @@ if (file_exists($newfile) & !$adminrequest) {
 
 if ($process) { // If the file hasn't been cached yet, create it.
 	// setup standard image options from the album theme if it exists
-	$iMutex = new Mutex('i',getOption('imageProcessorConcurrency'));
-	$iMutex-> lock();
 	$result = cacheImage($newfilename, $imgfile, $args, $allowWatermark, $theme, $album);
-	$iMutex -> unlock();
 	if (!$result) {
 		imageError('404 Not Found', sprintf(gettext('Image processing of %s resulted in a fatal error.'),filesystemToInternal($image)));
 	}

--- a/zp-core/setup/index.php
+++ b/zp-core/setup/index.php
@@ -1422,10 +1422,10 @@ if ($connection && $_zp_loggedin != ADMIN_RIGHTS) {
 		if (file_exists($serverpath.'/robots.txt')) {
 			checkmark(-2, gettext('<em>robots.txt</em> file'), gettext('<em>robots.txt</em> file [Not created]'), gettext('Setup did not create a <em>robots.txt</em> file because one already exists.'));
 		} else {
-			$text = explode('****delete all lines above and including this one *******'."\n", $robots);
+			$text = explode('****delete all lines above and including this one *******', $robots);
 			$d = dirname(dirname($_SERVER['SCRIPT_NAME']));
 			if ($d == '/') $d = '';
-			$robots = str_replace('/zenphoto', $d, $text[1]);
+			$robots = str_replace('/zenphoto', $d, trim($text[1]));
 			$rslt = file_put_contents($serverpath.'/robots.txt', $robots);
 			if ($rslt === false) {
 				$rslt = -1;


### PR DESCRIPTION
The update is not yet ready for inclusion:

The flock and mysql lock handling should be separated so that only that
code that is needed will be loaded. (image processing is memory
intensive, so every little bit helps.)

The change relies on mysqli wich may not be present. Indeed the database
handler model needs to be updated with whatever is needed to make this
work so that non-MySQL based implementations might have a chance of
working. At anyrate it needs to use library independent functions.

We would prefer that the lock be implemented as an object to reduce the
function polution of the environment.

The options for processing time limit probably are not something to
expose to our typical user.
