### PR TITLE
Update of portable URLs

### DIFF
--- a/zp-core/admin-edit.php
+++ b/zp-core/admin-edit.php
@@ -86,7 +86,7 @@ if (isset($_GET['action'])) {
 		case 'savesubalbumorder':
 			XSRFdefender('savealbumorder');
 			if ($_POST['checkallaction']=='noaction') {
-				$notify = postAlbumSort($album->get('id'));
+				$notify = postAlbumSort($album->getID());
 				if ($notify) {
 					if ($notify === true) {
 						$notify = '&saved';
@@ -1038,7 +1038,7 @@ $alb = removeParentAlbumNames($album);
 						<?php } ?>
 						<p class="buttons"><a href="<?php echo $image->getImageLink();?>" title="<?php echo gettext('View image on website'); ?>"><img src="images/view.png" alt="" /><strong><?php echo gettext('View'); ?></strong></a></p><br style="clear: both" />
 						<p><?php echo gettext('<strong>Filename:</strong>'); ?><br /><?php echo $image->filename; ?></p>
-						<p><?php echo gettext('<strong>Image id:</strong>'); ?> <?php echo $image->get('id'); ?></p>
+						<p><?php echo gettext('<strong>Image id:</strong>'); ?> <?php echo $image->getID(); ?></p>
 						<p><?php echo gettext("<strong>Dimensions:</strong>"); ?><br /><?php echo $image->getWidth(); ?> x  <?php echo $image->getHeight().' '.gettext('px'); ?></p>
 						<p><?php echo gettext("<strong>Size:</strong>"); ?><br /><?php echo byteConvert($image->getImageFootprint()); ?></p>
 						</td>
@@ -1282,12 +1282,12 @@ $alb = removeParentAlbumNames($album);
 					</tr>
 					<tr>
 						<td align="left" valign="top"><?php echo gettext("Title:"); ?></td>
-						<td><?php print_language_string_list($image->get('title'), $currentimage.'-title', false, NULL, '', '100%'); ?>
+						<td><?php print_language_string_list($image->getTitle('all'), $currentimage.'-title', false, NULL, '', '100%'); ?>
 					</tr>
 
 					<tr>
 						<td align="left" valign="top"><?php echo gettext("Description:"); ?></td>
-						<td><?php print_language_string_list($image->get('desc'), $currentimage.'-desc', true, NULL, 'texteditor', '100%'); ?></td>
+						<td><?php print_language_string_list($image->getDesc('all'), $currentimage.'-desc', true, NULL, 'texteditor', '100%'); ?></td>
 					</tr>
 
 					<?php
@@ -1354,7 +1354,7 @@ $alb = removeParentAlbumNames($album);
 						?>
 						<tr>
 							<td valign="top"><?php echo gettext("Custom data:"); ?></td>
-							<td><?php print_language_string_list($image->get('custom_data'), $currentimage.'-custom_data', true,NULL,'texteditor_imagecustomdata', '100%'); ?></td>
+							<td><?php print_language_string_list($image->getCustomData('all'), $currentimage.'-custom_data', true,NULL,'texteditor_imagecustomdata', '100%'); ?></td>
 						</tr>
 						<?php
 						} else {
@@ -1364,37 +1364,37 @@ $alb = removeParentAlbumNames($album);
 
 					<tr class="imageextrainfo" style="display: none">
 						<td valign="top"><?php echo gettext("Location:"); ?></td>
-						<td><?php print_language_string_list($image->get('location'), $currentimage.'-location', false, NULL,'', '100%'); ?>
+						<td><?php print_language_string_list($image->getLocation('all'), $currentimage.'-location', false, NULL,'', '100%'); ?>
 						</td>
 					</tr>
 
 					<tr class="imageextrainfo" style="display: none">
 						<td valign="top"><?php echo gettext("City:"); ?></td>
-						<td><?php print_language_string_list($image->get('city'), $currentimage.'-city', false, NULL,'', '100%'); ?>
+						<td><?php print_language_string_list($image->getCity('all'), $currentimage.'-city', false, NULL,'', '100%'); ?>
 						</td>
 					</tr>
 
 					<tr class="imageextrainfo" style="display: none">
 						<td valign="top"><?php echo gettext("State:"); ?></td>
-						<td><?php print_language_string_list($image->get('state'), $currentimage.'-state', false, NULL,'', '100%'); ?>
+						<td><?php print_language_string_list($image->getState('all'), $currentimage.'-state', false, NULL,'', '100%'); ?>
 						</td>
 					</tr>
 
 					<tr class="imageextrainfo" style="display: none">
 						<td valign="top"><?php echo gettext("Country:"); ?></td>
-						<td><?php print_language_string_list($image->get('country'), $currentimage.'-country', false, NULL,'', '100%'); ?>
+						<td><?php print_language_string_list($image->getCountry('all'), $currentimage.'-country', false, NULL,'', '100%'); ?>
 						</td>
 					</tr>
 
 					<tr class="imageextrainfo" style="display: none">
 						<td valign="top"><?php echo gettext("Credit:"); ?></td>
-						<td><?php print_language_string_list($image->get('credit'), $currentimage.'-credit', false, NULL,'', '100%'); ?>
+						<td><?php print_language_string_list($image->getCredit('all'), $currentimage.'-credit', false, NULL,'', '100%'); ?>
 						</td>
 					</tr>
 
 					<tr class="imageextrainfo" style="display: none">
 						<td valign="top"><?php echo gettext("Copyright:"); ?></td>
-						<td><?php print_language_string_list($image->get('copyright'), $currentimage.'-copyright', false, NULL,'', '100%'); ?>
+						<td><?php print_language_string_list($image->getCopyright('all'), $currentimage.'-copyright', false, NULL,'', '100%'); ?>
 						</td>
 					</tr>
 					<?php

--- a/zp-core/admin-functions.php
+++ b/zp-core/admin-functions.php
@@ -1213,7 +1213,7 @@ function printAlbumEditForm($index, $album, $collapse_tags, $buttons=true) {
 						<?php echo gettext("Album Title"); ?>:
 						</td>
 						<td class="middlecolumn">
-						<?php print_language_string_list($album->get('title'), $prefix."albumtitle",false,null,'','100%'); ?>
+						<?php print_language_string_list($album->getTitle('all'), $prefix."albumtitle",false,null,'','100%'); ?>
 						</td>
 					</tr>
 
@@ -1222,7 +1222,7 @@ function printAlbumEditForm($index, $album, $collapse_tags, $buttons=true) {
 						<?php echo gettext("Album Description:"); ?>
 						</td>
 						<td>
-						<?php	print_language_string_list($album->get('desc'), $prefix."albumdesc", true, NULL, 'texteditor','100%'); ?>
+						<?php	print_language_string_list($album->getDesc('all'), $prefix."albumdesc", true, NULL, 'texteditor','100%'); ?>
 						</td>
 					</tr>
 					<?php
@@ -1299,7 +1299,7 @@ function printAlbumEditForm($index, $album, $collapse_tags, $buttons=true) {
 									</span>
 								</p>
 								<p>
-								<?php print_language_string_list($album->get('password_hint'), "hint".$suffix, false, NULL, 'hint','100%'); ?>
+								<?php print_language_string_list($album->getPasswordHint('all'), "hint".$suffix, false, NULL, 'hint','100%'); ?>
 								</p>
 							</td>
 						</tr>
@@ -1342,7 +1342,7 @@ function printAlbumEditForm($index, $album, $collapse_tags, $buttons=true) {
 						?>
 						<tr>
 							<td class="leftcolumn"><?php echo gettext("Custom data:"); ?></td>
-							<td><?php print_language_string_list($album->get('custom_data'), $prefix."album_custom_data", true , NULL, 'texteditor_albumcustomdata','100%'); ?></td>
+							<td><?php print_language_string_list($album->getCustomData('all'), $prefix."album_custom_data", true , NULL, 'texteditor_albumcustomdata','100%'); ?></td>
 						</tr>
 						<?php
 					} else {
@@ -2430,6 +2430,7 @@ $_zp_current_locale = NULL;
  */
 function print_language_string_list($dbstring, $name, $textbox=false, $locale=NULL, $edit='', $wide=TEXT_INPUT_SIZE, $ulclass='language_string_list', $rows=6) {
 	global $_zp_active_languages, $_zp_current_locale;
+	$dbstring = zpFunctions::unTagURLs($dbstring);
 	if (!empty($edit)) $edit = ' class="'.$edit.'"';
 	if (is_null($locale)) {
 		if (is_null($_zp_current_locale)) {
@@ -3492,7 +3493,7 @@ function printNestedAlbumsList($albums, $show_thumb) {
 		} else {
 			$nonest = '';
 		}
-		echo str_pad("\t",$indent-1,"\t")."<li id=\"id_".$albumobj->get('id')."\"$nonest >";
+		echo str_pad("\t",$indent-1,"\t")."<li id=\"id_".$albumobj->getID()."\"$nonest >";
 		printAlbumEditRow($albumobj, $show_thumb);
 		$open[$indent]++;
 	}

--- a/zp-core/admin-options.php
+++ b/zp-core/admin-options.php
@@ -118,9 +118,9 @@ if (isset($_GET['action'])) {
 			$_zp_gallery->setGallerySession((int) isset($_POST['album_session']));
 			$_zp_gallery->setThumbSelectImages((int) isset($_POST['thumb_select_images']));
 			$_zp_gallery->setSecondLevelThumbs((int) isset($_POST['multilevel_thumb_select_images']));
-			$_zp_gallery->set('gallery_title', process_language_string_save('gallery_title', 2));
-			$_zp_gallery->set('Gallery_description', process_language_string_save('Gallery_description', 1));
-			$_zp_gallery->set('website_title', process_language_string_save('website_title', 2));
+			$_zp_gallery->setTitle( process_language_string_save('gallery_title', 2));
+			$_zp_gallery->setDesc(process_language_string_save('Gallery_description', 1));
+			$_zp_gallery->setWebsiteTitle(process_language_string_save('website_title', 2));
 			$web = sanitize($_POST['website_url'],3);
 			$_zp_gallery->setWebsiteURL($web);
 			$_zp_gallery->setAlbumUseImagedate((int) isset($_POST['album_use_new_image_date']));
@@ -908,14 +908,14 @@ if ($subtab == 'gallery' && zp_loggedin(OPTIONS_RIGHTS)) {
 				<tr>
 					<td width="175"><?php echo gettext("Gallery title:"); ?></td>
 					<td width="350">
-					<?php print_language_string_list($_zp_gallery->get('gallery_title'), 'gallery_title') ?>
+					<?php print_language_string_list($_zp_gallery->getTitle('all'), 'gallery_title') ?>
 					</td>
 					<td><?php echo gettext("What you want to call your Zenphoto site."); ?></td>
 				</tr>
 				<tr>
 					<td width="175"><?php echo gettext("Gallery description:"); ?></td>
 					<td width="350">
-					<?php print_language_string_list($_zp_gallery->get('Gallery_description'), 'Gallery_description', true, NULL, 'texteditor') ?>
+					<?php print_language_string_list($_zp_gallery->getDesc('all'), 'Gallery_description', true, NULL, 'texteditor') ?>
 					</td>
 					<td><?php echo gettext("A brief description of your gallery. Some themes may display this text."); ?></td>
 				</tr>
@@ -1016,7 +1016,7 @@ if ($subtab == 'gallery' && zp_loggedin(OPTIONS_RIGHTS)) {
 							<?php echo gettext("Gallery password hint:"); ?>
 						</td>
 						<td>
-							<?php print_language_string_list($_zp_gallery->get('gallery_hint'), 'hint', false, NULL, 'hint') ?>
+							<?php print_language_string_list($_zp_gallery->getPasswordHint('all'), 'hint', false, NULL, 'hint') ?>
 						</td>
 						<td>
 							<?php echo gettext("A reminder hint for the password."); ?>
@@ -1059,7 +1059,7 @@ if ($subtab == 'gallery' && zp_loggedin(OPTIONS_RIGHTS)) {
 				<tr>
 					<td><?php echo gettext("Website title:"); ?></td>
 					<td>
-					<?php print_language_string_list($_zp_gallery->get('website_title'), 'website_title') ?>
+					<?php print_language_string_list($_zp_gallery->getWebsiteTitle('all'), 'website_title') ?>
 					</td>
 					<td><?php echo gettext("Your web site title."); ?></td>
 				</tr>

--- a/zp-core/class-album.php
+++ b/zp-core/class-album.php
@@ -75,7 +75,12 @@ class AlbumBase extends MediaObject {
 	 * @return string
 	 */
 	function getLocation($locale=NULL) {
-		return get_language_string($this->get('location'), $locale);
+		$text = $this->get('location');
+		if ($locale!=='all') {
+			$text = get_language_string($text,$locale);
+		}
+		$text = zpFunctions::unTagURLs($text);
+		return $text;
 	}
 
 	/**
@@ -84,7 +89,7 @@ class AlbumBase extends MediaObject {
 	 * @param string $place text for the place field
 	 */
 	function setLocation($place) {
-		$this->set('location', $place);
+		$this->set('location', zpFunctions::tagURLs($place));
 	}
 
 
@@ -754,6 +759,10 @@ class Album extends AlbumBase {
 			return $this->parentalbum;
 		}
 		return NULL;
+	}
+
+	function getParentID() {
+		return $this->get('parentid');
 	}
 
 	/**

--- a/zp-core/class-gallery.php
+++ b/zp-core/class-gallery.php
@@ -42,7 +42,16 @@ class Gallery {
 	 * @return string
 	 */
 	function getTitle($locale=NULL) {
-		return get_language_string($this->get('gallery_title'),$locale);
+		$text = $this->get('gallery_title');
+		if ($locale!=='all') {
+			$text = get_language_string($text,$locale);
+		}
+		$text = zpFunctions::unTagURLs($text);
+		return $text;
+	}
+
+	function setTitle($title) {
+		$this->set('gallery_title',zpFunctions::tagURLs($title));
 	}
 
 	/**
@@ -51,7 +60,20 @@ class Gallery {
 	 * @return string
 	 */
 	function getDesc($locale=NULL) {
-		return get_language_string($this->get('Gallery_description'),$locale);
+		$text = $this->get('Gallery_description');
+		if ($locale!=='all') {
+			$text = get_language_string($text,$locale);
+		}
+		$text = zpFunctions::unTagURLs($text);
+		return $text;
+	}
+	/**
+	 * Sets the gallery description
+	 * @param string $desc
+	 */
+	function setDesc($desc) {
+		$desc = zpFunctions::tagURLs($desc);
+		$this->set('Gallery_description', $desc);
 	}
 
 	/**
@@ -75,10 +97,15 @@ class Gallery {
 	 * @return string
 	 */
 	function getPasswordHint($locale=NULL) {
-		return get_language_string($this->get('gallery_hint'),$locale);
+		$text = $this->get('gallery_hint');
+		if ($locale!=='all') {
+			$text = get_language_string($text,$locale);
+		}
+		$text = zpFunctions::unTagURLs($text);
+		return $text;
 	}
 	function setPasswordHint($value) {
-		$this->set('gallery_hint', $value);
+		$this->set('gallery_hint', zpFunctions::tagURLs($value));
 	}
 
 	function getUser() {
@@ -771,10 +798,15 @@ class Gallery {
 	 * Title to be used for the home (not Zenphoto gallery) WEBsite
 	 */
 	function getWebsiteTitle($locale=NULL) {
-		return get_language_string($this->get('website_title'),$locale);
+		$text = $this->get('website_title');
+		if ($locale!=='all') {
+			$text = get_language_string($text,$locale);
+		}
+		$text = zpFunctions::unTagURLs($text);
+		return $text;
 	}
 	function setWebsiteTitle($value) {
-		$this->set('website_title', $value);
+		$this->set('website_title', zpFunctions::tagURLs($value));
 	}
 
 	/**

--- a/zp-core/class-image.php
+++ b/zp-core/class-image.php
@@ -597,7 +597,12 @@ class _Image extends MediaObject {
 	 * @return string
 	 */
 	function getLocation($locale=NULL) {
-		return get_language_string($this->get('location'),$locale);
+		$text = $this->getLocation('all');
+		if ($locale!=='all') {
+			$text = get_language_string($text,$locale);
+		}
+		$text = zpFunctions::unTagURLs($text);
+		return $text;
 	}
 
 	/**
@@ -613,7 +618,12 @@ class _Image extends MediaObject {
 	 * @return string
 	 */
 	function getCity($locale=NULL) {
-		return get_language_string($this->get('city'),$locale);
+		$text = $this->getCity('all');
+		if ($locale!=='all') {
+			$text = get_language_string($text,$locale);
+		}
+		$text = zpFunctions::unTagURLs($text);
+		return $text;
 	}
 
 	/**
@@ -621,7 +631,9 @@ class _Image extends MediaObject {
 	 *
 	 * @param string $city text for the city
 	 */
-	function setCity($city) { $this->set('city', $city); }
+	function setCity($city) {
+		$this->set('city', zpFunctions::tagURLs($city));
+	}
 
 	/**
 	 * Returns the state field of the image
@@ -629,7 +641,12 @@ class _Image extends MediaObject {
 	 * @return string
 	 */
 	function getState($locale=NULL) {
-		return get_language_string($this->get('state'),$locale);
+		$text = $this->getState('all');
+		if ($locale!=='all') {
+			$text = get_language_string($text,$locale);
+		}
+		$text = zpFunctions::unTagURLs($text);
+		return $text;
 	}
 
 	/**
@@ -637,7 +654,9 @@ class _Image extends MediaObject {
 	 *
 	 * @param string $state text for the state
 	 */
-	function setState($state) { $this->set('state', $state); }
+	function setState($state) {
+		$this->set('state', zpFunctions::tagURLs($state));
+	}
 
 	/**
 	 * Returns the country field of the image
@@ -645,7 +664,12 @@ class _Image extends MediaObject {
 	 * @return string
 	 */
 	function getCountry($locale=NULL) {
-		return get_language_string($this->get('country'),$locale);
+		$text = $this->getCountry('all');
+		if ($locale!=='all') {
+			$text = get_language_string($text,$locale);
+		}
+		$text = zpFunctions::unTagURLs($text);
+		return $text;
 	}
 
 	/**
@@ -653,7 +677,9 @@ class _Image extends MediaObject {
 	 *
 	 * @param string $country text for the country filed
 	 */
-	function setCountry($country) { $this->set('country', $country); }
+	function setCountry($country) {
+		$this->set('country', zpFunctions::tagURLs($country));
+	}
 
 	/**
 	 * Returns the credit field of the image
@@ -661,7 +687,12 @@ class _Image extends MediaObject {
 	 * @return string
 	 */
 	function getCredit($locale=NULL) {
-		return get_language_string($this->get('credit'),$locale=NULL);
+		$text = $this->getCredit('all');
+		if ($locale!=='all') {
+			$text = get_language_string($text,$locale);
+		}
+		$text = zpFunctions::unTagURLs($text);
+		return $text;
 	}
 
 	/**
@@ -669,7 +700,9 @@ class _Image extends MediaObject {
 	 *
 	 * @param string $credit text for the credit field
 	 */
-	function setCredit($credit) { $this->set('credit', $credit); }
+	function setCredit($credit) {
+		$this->set('credit', zpFunctions::tagURLs($credit));
+	}
 
 	/**
 	 * Returns the copyright field of the image
@@ -677,7 +710,12 @@ class _Image extends MediaObject {
 	 * @return string
 	 */
 	function getCopyright($locale=NULL) {
-		return get_language_string($this->get('copyright'),$locale);
+		$text = $this->getCopyright('all');
+		if ($locale!=='all') {
+			$text = get_language_string($text,$locale);
+		}
+		$text = zpFunctions::unTagURLs($text);
+		return $text;
 	}
 
 	/**
@@ -685,7 +723,9 @@ class _Image extends MediaObject {
 	 *
 	 * @param string $copyright text for the copyright field
 	 */
-	function setCopyright($copyright) { $this->set('copyright', $copyright); }
+	function setCopyright($copyright) {
+		$this->set('copyright', zpFunctions::tagURLs($copyright));
+	}
 
 	/**
 	 * Permanently delete this image (permanent: be careful!)

--- a/zp-core/class-rss.php
+++ b/zp-core/class-rss.php
@@ -871,14 +871,14 @@ protected function getRSSCombinewsAlbums() {
 		switch($itemtype) {
 			case 'news':
 				$obj = new ZenpageNews($item['titlelink']);
-				$title = $feeditem['title'] = get_language_string($obj->get('title'),$this->locale);
+				$title = $feeditem['title'] = get_language_string($obj->getTitle('all'),$this->locale);
 				$link = getNewsURL($obj->getTitlelink());
 				$count2 = 0;
 				$plaincategories = $obj->getCategories();
 				$categories = '';
 				foreach($plaincategories as $cat){
 					$catobj = new ZenpageCategory($cat['titlelink']);
-					$categories .= get_language_string($catobj->get('title'), $this->locale).',';
+					$categories .= get_language_string($catobj->getTitle('all'), $this->locale).',';
 				}
 				$categories = rtrim($categories, ',');
 				$feeditem['desc'] = shortenContent(get_language_string($obj->get('content'),$this->locale),getOption('zenpage_rss_length'), '...');
@@ -886,16 +886,16 @@ protected function getRSSCombinewsAlbums() {
 			case 'images':
 				$albumobj = new Album(NULL,$item['albumname']);
 				$obj = newImage($albumobj,$item['titlelink']);
-				$categories = get_language_string($albumobj->get('title'),$this->locale);
-				$feeditem['title'] = strip_tags(get_language_string($obj->get('title'),$this->locale));
-				$title = get_language_string($obj->get('title'),$this->locale);
+				$categories = get_language_string($albumobj->getTitle('all'),$this->locale);
+				$feeditem['title'] = strip_tags(get_language_string($obj->getTitle('all'),$this->locale));
+				$title = get_language_string($obj->getTitle('all'),$this->locale);
 				$link = $obj->getImageLink();
 				$filename = $obj->getFilename();
 				$ext = getSuffix($filename);
 				$album = $albumobj->getFolder();
 				$fullimagelink = $this->host.WEBPATH.'/albums/'.$album.'/'.$filename;
 				$imagefile = "albums/".$album."/".$filename;
-				$content = shortenContent(get_language_string($obj->get('desc'),$this->locale),getOption('zenpage_rss_length'), '...');
+				$content = shortenContent($obj->getDesc($this->locale),getOption('zenpage_rss_length'), '...');
 				if(isImagePhoto($obj)) {
 					$feeditem['desc'] = '<a title="'.html_encode($feeditem['title']).' in '.html_encode($categories).'" href="'.PROTOCOL.'://'.$this->host.$link.'"><img border="0" src="'.PROTOCOL.'://'.$this->host.WEBPATH.'/'.ZENFOLDER.'/i.php?a='.$album.'&i='.$filename.'&s='.$this->imagesize.'" alt="'. html_encode($feeditem['title']).'"></a><br />'.$content;
 				} else {
@@ -907,13 +907,13 @@ protected function getRSSCombinewsAlbums() {
 				break;
 			case 'albums':
 				$obj = new Album(NULL,$item['albumname']);
-				$categories = get_language_string($obj->get('title'),$this->locale);
-				$feeditem['title'] = strip_tags(get_language_string($obj->get('title'),$this->locale));
-				$title = get_language_string($obj->get('title'),$this->locale);
+				$categories = get_language_string($obj->getTitle('all'),$this->locale);
+				$feeditem['title'] = strip_tags(get_language_string($obj->getTitle('all'),$this->locale));
+				$title = get_language_string($obj->getTitle('all'),$this->locale);
 				$link = $obj->getAlbumLink();
 				$album = $obj->getFolder();
 				$albumthumb = $obj->getAlbumThumbImage();
-				$content = shortenContent(get_language_string($obj->get('desc'),$this->locale),getOption('zenpage_rss_length'), '...');
+				$content = shortenContent($obj->getDesc($this->locale),getOption('zenpage_rss_length'), '...');
 				if(isImagePhoto($obj)) {
 					$feeditem['desc'] = '<a title="'.html_encode($feeditem['title']).'" href="'.PROTOCOL.'://'.$this->host.$link.'"><img border="0" src="'.PROTOCOL.'://'.$this->host.WEBPATH.'/'.ZENFOLDER.'/i.php?a='.$album.'&i='.html_encode($albumthumb->filename).'&s='.$this->imagesize.'" alt="'. html_encode($feeditem['title']).'"></a><br />'.$content;
 				} else {

--- a/zp-core/class-search.php
+++ b/zp-core/class-search.php
@@ -717,12 +717,12 @@ class SearchEngine {
 			foreach ($list as $category) {
 				if (in_array($category['title'], $this->category_list)) {
 					$catobj = new ZenpageCategory($category['titlelink']);
-					$cat .= ' `cat_id`='.$catobj->get('id').' OR';
+					$cat .= ' `cat_id`='.$catobj->getID().' OR';
 					$subcats = $catobj->getSubCategories();
 					if($subcats) {
 						foreach($subcats as $subcat) {
 							$catobj = new ZenpageCategory($subcat);
-							$cat .= ' `cat_id`='.$catobj->get('id').' OR';
+							$cat .= ' `cat_id`='.$catobj->getID().' OR';
 						}
 					}
 				}

--- a/zp-core/classes.php
+++ b/zp-core/classes.php
@@ -418,7 +418,12 @@ class ThemeObject extends PersistentObject {
 	 * @return string
 	 */
 	function getTitle($locale=NULL) {
-		return get_language_string($this->get('title'),$locale);
+		$text = $this->get('title');
+		if ($locale!=='all') {
+			$text = get_language_string($text,$locale);
+		}
+		$text = zpFunctions::unTagURLs($text);
+		return $text;
 	}
 
 	/**
@@ -426,7 +431,9 @@ class ThemeObject extends PersistentObject {
 	 *
 	 * @param string $title the title
 	 */
-	function setTitle($title) { $this->set('title', $title); }
+	function setTitle($title) {
+		$this->set('title', zpFunctions::tagURLs($title));
+	}
 
 	/**
 	 * Returns the partent id
@@ -564,7 +571,12 @@ class ThemeObject extends PersistentObject {
 	 * @return string
 	 */
 	function getCustomData($locale=NULL) {
-		return get_language_string($this->get('custom_data'),$locale);
+		$text = $this->get('custom_data');
+		if ($locale!=='all') {
+			$text = get_language_string($text,$locale);
+		}
+		$text = zpFunctions::unTagURLs($text);
+		return $text;
 	}
 
 	/**
@@ -572,7 +584,9 @@ class ThemeObject extends PersistentObject {
 	 *
 	 * @param string $val the value to be put in custom_data
 	 */
-	function setCustomData($val) { $this->set('custom_data', $val); }
+	function setCustomData($val) {
+		$this->set('custom_data', zpFunctions::tagURLs($val));
+	}
 
 	/**
 	 * Retuns true if comments are allowed
@@ -716,7 +730,12 @@ class MediaObject extends ThemeObject {
 	 * @return string
 	 */
 	function getDesc($locale=NULL) {
-		return get_language_string($this->get('desc'),$locale);
+		$text =  $this->get('desc');
+		if ($locale!=='all') {
+			$text =  get_language_string($text,$locale);
+		}
+		$text = zpFunctions::unTagURLs($text);
+		return $text;
 	}
 
 	/**
@@ -724,7 +743,10 @@ class MediaObject extends ThemeObject {
 	 *
 	 * @param string $desc description text
 	 */
-	function setDesc($desc) { $this->set('desc', $desc); }
+	function setDesc($desc) {
+		$desc = zpFunctions::tagURLs($desc);
+		$this->set('desc', $desc);
+	}
 
 	/**
 	 * Returns the sort order
@@ -782,7 +804,12 @@ class MediaObject extends ThemeObject {
 	 * @return string
 	 */
 	function getPasswordHint($locale=NULL) {
-		return get_language_string($this->get('password_hint'),$locale);
+		$text = $this->get('password_hint');
+		if ($locale!=='all') {
+			$text = get_language_string($text,$locale);
+		}
+		$text = zpFunctions::unTagURLs($text);
+		return $text;
 	}
 
 	/**
@@ -790,7 +817,9 @@ class MediaObject extends ThemeObject {
 	 *
 	 * @param string $hint the hint text
 	 */
-	function setPasswordHint($hint) { $this->set('password_hint', $hint); }
+	function setPasswordHint($hint) {
+		$this->set('password_hint', zpFunctions::tagURLs($hint));
+	}
 
 	/**
 	* Returns the expire date

--- a/zp-core/full-image.php
+++ b/zp-core/full-image.php
@@ -54,14 +54,14 @@ if (($hash || !$albumobj->checkAccess()) && !zp_loggedin(VIEW_FULLIMAGE_RIGHTS))
 	$show = getOption('protected_image_user');
 	if (empty($hash)) {	// check for album password
 		$hash = $albumobj->getPassword();
-		$authType = "zp_album_auth_" . $albumobj->get('id');
+		$authType = "zp_album_auth_" . $albumobj->getID();
 		$hint = $albumobj->getPasswordHint();
 		$show = $albumobj->getUser();
 		if (empty($hash)) {
 			$albumobj = $albumobj->getParent();
 			while (!is_null($albumobj)) {
 				$hash = $albumobj->getPassword();
-				$authType = "zp_album_auth_" . $albumobj->get('id');
+				$authType = "zp_album_auth_" . $albumobj->getID();
 				$hint = $albumobj->getPasswordHint();
 				$show = $albumobj->getUser();
 				if (!empty($hash)) {

--- a/zp-core/functions.php
+++ b/zp-core/functions.php
@@ -419,7 +419,7 @@ function checkAlbumPassword($album, &$hint=NULL) {
 		$album = $album->getParent();
 		while (!is_null($album)) {
 			$hash = $album->getPassword();
-			$authType = "zp_album_auth_" . $album->get('id');
+			$authType = "zp_album_auth_" . $album->getID();
 			$saved_auth = zp_getCookie($authType);
 
 			if (!empty($hash)) {
@@ -446,7 +446,7 @@ function checkAlbumPassword($album, &$hint=NULL) {
 			}
 		}
 	} else {
-		$authType = "zp_album_auth_" . $album->get('id');
+		$authType = "zp_album_auth_" . $album->getID();
 		$saved_auth = zp_getCookie($authType);
 		if ($saved_auth != $hash) {
 			$hint = $album->getPasswordHint();
@@ -693,7 +693,7 @@ function populateManagedObjectsList($type,$id,$rights=false) {
 		return array();
 	}
 	$cv = array();
-	if (empty($type) || $type=='albums' || $type=='album') {
+	if (empty($type) || substr($type,0,5)=='album') {
 		$sql = "SELECT ".prefix('albums').".`folder`,".prefix('albums').".`title`,".prefix('admin_to_object').".`edit` FROM ".prefix('albums').", ".
 						prefix('admin_to_object')." WHERE ".prefix('admin_to_object').".adminid=".$id.
 						" AND ".prefix('albums').".id=".prefix('admin_to_object').".objectid AND ".prefix('admin_to_object').".type LIKE 'album%'";
@@ -1580,7 +1580,7 @@ function zp_handle_password($authType=NULL, $check_auth=NULL, $check_user=NULL) 
 			$check_auth = getOption('search_password');
 			$check_user = getOption('search_user');
 		} else if (in_context(ZP_ALBUM)) { // album page
-			$authType = "zp_album_auth_" . $_zp_current_album->get('id');
+			$authType = "zp_album_auth_" . $_zp_current_album->getID();
 			$check_auth = $_zp_current_album->getPassword();
 			$check_user = $_zp_current_album->getUser();
 			if (empty($check_auth)) {
@@ -1588,13 +1588,13 @@ function zp_handle_password($authType=NULL, $check_auth=NULL, $check_user=NULL) 
 				while (!is_null($parent)) {
 					$check_auth = $parent->getPassword();
 					$check_user = $parent->getUser();
-					$authType = "zp_album_auth_" . $parent->get('id');
+					$authType = "zp_album_auth_" . $parent->getID();
 					if (!empty($check_auth)) { break; }
 					$parent = $parent->getParent();
 				}
 			}
 		} else if (in_context(ZP_ZENPAGE_PAGE)) {
-			$authType = "zp_page_auth_" . $_zp_current_zenpage_page->get('id');
+			$authType = "zp_page_auth_" . $_zp_current_zenpage_page->getID();
 			$check_auth = $_zp_current_zenpage_page->getPassword();
 			$check_user = $_zp_current_zenpage_page->getUser();
 			if (empty($check_auth)) {
@@ -1605,7 +1605,7 @@ function zp_handle_password($authType=NULL, $check_auth=NULL, $check_user=NULL) 
 					$sql = 'SELECT `titlelink` FROM '.prefix('pages').' WHERE `id`='.$parentID;
 					$result = query_single_row($sql);
 					$pageobj = new ZenpagePage($result['titlelink']);
-					$authType = "zp_page_auth_" . $pageobj->get('id');
+					$authType = "zp_page_auth_" . $pageobj->getID();
 					$check_auth = $pageobj->getPassword();
 					$check_user = $pageobj->getUser();
 				}
@@ -2256,6 +2256,17 @@ class zpFunctions {
 			return true;
 		}
 		return false;
+	}
+
+	static function tagURLs($text) {
+		$text = preg_replace('|'.FULLWEBPATH.'|is', '{*FULLWEBPATH*}', $text);
+		$text = preg_replace('|'.WEBPATH.'|is', '{*WEBPATH*}', $text);
+		return $text;
+	}
+	static function unTagURLs($text) {
+		$text = preg_replace('|\{\*FULLWEBPATH\*\}|', FULLWEBPATH, $text);
+		$text = preg_replace('|\{\*WEBPATH\*\}|', WEBPATH, $text);
+		return $text;
 	}
 
 }

--- a/zp-core/setup/setup-functions.php
+++ b/zp-core/setup/setup-functions.php
@@ -421,7 +421,7 @@ function updateConfigItem($item, $value, $quote=true) {
 function checkAlbumParentid($albumname, $id) {
 	Global $_zp_gallery;
 	$album = new Album(NULL, $albumname);
-	$oldid = $album->get('parentid');
+	$oldid = $album->getParentID();
 	if ($oldid != $id) {
 		$album->set('parentid', $id);
 		$album->save();

--- a/zp-core/template-functions.php
+++ b/zp-core/template-functions.php
@@ -1393,6 +1393,7 @@ function printField($context, $field, $convertBR = NULL, $override = false, $lab
 	} else {
 		$text = trim(get_language_string($object->get($field)));
 	}
+	$text = zpFunctions::unTagURLs($text);
 
 	$text = html_encodeTagged($text);
 	if ($convertBR) {

--- a/zp-core/utilities/gallery_statistics.php
+++ b/zp-core/utilities/gallery_statistics.php
@@ -198,7 +198,7 @@ function printBarGraph($sortorder="mostimages",$type="albums",$from_number=0, $t
 					$albums = array();
 					foreach ($allalbums as $album) {
 						$albumobj = new Album(NULL,$album['folder']);
-						$albumentry = array("id" => $albumobj->get('id'), "title" => $albumobj->getTitle(), "folder" => $albumobj->name,"imagenumber" => $albumobj->getNumImages(), "show" => $albumobj->get("show"));
+						$albumentry = array("id" => $albumobj->getID(), "title" => $albumobj->getTitle(), "folder" => $albumobj->name,"imagenumber" => $albumobj->getNumImages(), "show" => $albumobj->getShow());
 						array_unshift($albums,$albumentry);
 					}
 					$maxvalue = 1;

--- a/zp-core/version.php
+++ b/zp-core/version.php
@@ -1,4 +1,4 @@
 <?php // This file contains version info only and is automatically updated. DO NOT EDIT.
 define('ZENPHOTO_VERSION', '1.4.4-DEV');
-define('ZENPHOTO_RELEASE', 10994);
+define('ZENPHOTO_RELEASE', 10996);
 ?>

--- a/zp-core/zp-extensions/flowplayer3.php
+++ b/zp-core/zp-extensions/flowplayer3.php
@@ -465,7 +465,7 @@ function flowplayerPlaylist($option="playlist",$albumfolder="") {
 					$liststyle = 'div';
 				}
 			echo '<div class="flowplayer3_playlistwrapper">
-			<a id="player'.$album->get('id').'" class="flowplayer3_playlist" style="display:block; width: '.$playlistwidth.'px; height: '.$playlistheight.'px;">
+			<a id="player'.$album->getID().'" class="flowplayer3_playlist" style="display:block; width: '.$playlistwidth.'px; height: '.$playlistheight.'px;">
 			'.$videoThumbImg.'
 			</a>
 			<script type="text/javascript">
@@ -473,13 +473,13 @@ function flowplayerPlaylist($option="playlist",$albumfolder="") {
 			$(function() {
 
 			$("div.playlist").scrollable({
-				items:"'.$liststyle.'.clips'.$album->get('id').'",
+				items:"'.$liststyle.'.clips'.$album->getID().'",
 				vertical:true,
 				next:"a.down",
 				prev:"a.up",
 				mousewheel: true
 			});
-			flowplayer("player'.$album->get('id').'","'.WEBPATH . '/' . ZENFOLDER . '/'.PLUGIN_FOLDER . '/flowplayer3/'.$swf.'", {
+			flowplayer("player'.$album->getID().'","'.WEBPATH . '/' . ZENFOLDER . '/'.PLUGIN_FOLDER . '/flowplayer3/'.$swf.'", {
 			plugins: {
 				audio: {
 					url: "'.$audio.'"
@@ -536,7 +536,7 @@ function flowplayerPlaylist($option="playlist",$albumfolder="") {
 			} // foreach end
 			echo 'playlist: ['.substr($list,0,-1).']
 			});
-			flowplayer("player'.$album->get('id').'").playlist("'.$liststyle.'.clips'.$album->get('id').':first", {loop:true});
+			flowplayer("player'.$album->getID().'").playlist("'.$liststyle.'.clips'.$album->getID().':first", {loop:true});
 			});
 			// ]]> -->
 			</script>';
@@ -544,8 +544,8 @@ function flowplayerPlaylist($option="playlist",$albumfolder="") {
 		<div class="wrapper">
 					<a class="up" title="Up"></a>
 
-			<div class="playlist playlist<?php echo $album->get('id'); ?>">
-				<<?php echo $liststyle; ?> class="clips clips<?php echo $album->get('id'); ?>">
+			<div class="playlist playlist<?php echo $album->getID(); ?>">
+				<<?php echo $liststyle; ?> class="clips clips<?php echo $album->getID(); ?>">
 					<!-- single playlist entry as an "template" -->
 					<?php if($liststyle == 'ol') { ?> <li> <?php } ?>
 					<a href="${url}">${title}</a>

--- a/zp-core/zp-extensions/image_album_statistics.php
+++ b/zp-core/zp-extensions/image_album_statistics.php
@@ -230,7 +230,7 @@ function printAlbumStatisticItem($album, $option, $showtitle=false, $showdate=fa
 		echo "<p>".sprintf(gettext('Rating: %1$u (Votes: %2$u)'),$rating,$tempalbum->get("total_votes"))."</p>";
 	}
 	if($showstatistic === "hitcounter" OR $showstatistic === "rating+hitcounter") {
-		$hitcounter = $tempalbum->get("hitcounter");
+		$hitcounter = $tempalbum->getHitcounter();
 		if(empty($hitcounter)) { $hitcounter = "0"; }
 		echo "<p>".sprintf(gettext("Views: %u"),$hitcounter)."</p>";
 	}
@@ -519,7 +519,7 @@ function printImageStatistic($number, $option, $albumfolder='', $showtitle=false
 			echo "<p>".sprintf(gettext('Rating: %1$u (Votes: %2$u)'),$rating,$votes)."</p>";
 		}
 		if($showstatistic === "hitcounter" OR $showstatistic === "rating+hitcounter") {
-			$hitcounter = $image->get("hitcounter");
+			$hitcounter = $image->getHitcounter();
 			if(empty($hitcounter)) { $hitcounter = "0"; }
 			echo "<p>".sprintf(gettext("Views: %u"),$hitcounter)."</p>";
 		}

--- a/zp-core/zp-extensions/menu_manager/menu_manager-admin-functions.php
+++ b/zp-core/zp-extensions/menu_manager/menu_manager-admin-functions.php
@@ -297,7 +297,7 @@ function publishItem($id,$show,$menuset) {
  */
 function addSubalbumMenus($menuset, $id, $link, $sort) {
 	$album = new Album(NULL, $link);
-	$show = $album->get('show');
+	$show = $album->getShow();
 	$title = $album->getTitle();
 	$sql = "INSERT INTO ".prefix('menu')." (`link`,`type`,`title`,`show`,`menuset`,`sort_order`, `parentid`) ".
 																				'VALUES ('.db_quote($link).', "album",'.db_quote($album->name).', '.$show.','.db_quote($menuset).','.db_quote($sort).','.$id.')';

--- a/zp-core/zp-extensions/mergedRSS.php
+++ b/zp-core/zp-extensions/mergedRSS.php
@@ -40,7 +40,7 @@ if(isset($_GET['mergedrss'])) {
 	}
 	$gallery = new Gallery();
 	// Create new MergedRSS object with desired parameters
-	$MergedRSS = new MergedRSS($feeds, strip_tags(get_language_string($gallery->get('gallery_title'), $locale)), FULLWEBPATH, strip_tags(get_language_string($gallery->get('Gallery_description'), $locale)), $feed_date);
+	$MergedRSS = new MergedRSS($feeds, strip_tags(get_language_string($gallery->getTitle(), $locale)), FULLWEBPATH, strip_tags(get_language_string($gallery->getDesc(), $locale)), $feed_date);
 
 	//Export the first 10 items to screen
 	$MergedRSS->export(false, true, 20); //getOption('feed_items')

--- a/zp-core/zp-extensions/publishContent/publishContent.php
+++ b/zp-core/zp-extensions/publishContent/publishContent.php
@@ -389,7 +389,7 @@ if (zp_loggedin(ADMIN_RIGHTS)) {	//only admin should be allowed to do this
 		<?php
 		foreach ($publish_images_list as $key=>$imagelist) {
 			$album = new Album(NULL,$key);
-			$albumid = $album->get('id');
+			$albumid = $album->getID();
 			$imagelist = array_flip($imagelist);
 			natcasesort($imagelist);
 			$imagelist = array_flip($imagelist);

--- a/zp-core/zp-extensions/rating.php
+++ b/zp-core/zp-extensions/rating.php
@@ -302,7 +302,7 @@ function printRating($vote=3, $object=NULL, $text=true) {
 	$split_stars = max(1,getOption('rating_split_stars'));
 	$rating = $object->get('rating');
 	$votes = $object->get('total_votes');
-	$id = $object->get('id');
+	$id = $object->getID();
 	$unique = '_'.$table.'_'.$id;
 
 	$ip = jquery_rating::id();

--- a/zp-core/zp-extensions/sitemap-extended.php
+++ b/zp-core/zp-extensions/sitemap-extended.php
@@ -674,18 +674,18 @@ function getSitemapGoogleImageVideoExtras($albumobj,$imageobj,$locale) {
 	//$path = FULLWEBPATH.'/'.rewrite_path($locale.'/'.pathurlencode($albumobj->name).'/'.urlencode($imageobj->filename).IM_SUFFIX,'?album='.pathurlencode($albumobj->name).'&amp;image='.urlencode($imageobj->filename),false);
 	if(isImageVideo($imageobj) && in_array($ext,array('.mpg','.mpeg','.mp4','.m4v','.mov','.wmv','.asf','.avi','.ra','.ram','.flv','.swf'))) { // google says it can index these so we list them even if unsupported by Zenphoto
 		$data .= sitemap_echonl("\t\t<video:video>\n\t\t\t<video:thumbnail_loc>".$host.html_encode($imageobj->getThumb())."</video:thumbnail_loc>\n");
-		$data .= sitemap_echonl("\t\t\t<video:title>".html_encode(get_language_string($imageobj->get('title'),$locale))."</video:title>");
+		$data .= sitemap_echonl("\t\t\t<video:title>".html_encode($imageobj->getTitle($locale))."</video:title>");
 		if ($imageobj->getDesc()) {
-			$data .= sitemap_echonl("\t\t\t<video:description>".html_encode(strip_tags(get_language_string($imageobj->get('desc'),$locale)))."</video:description>");
+			$data .= sitemap_echonl("\t\t\t<video:description>".html_encode(strip_tags($imageobj->getDesc($locale)))."</video:description>");
 		}
 		$data .= sitemap_echonl("\t\t\t<video:content_loc>".$host.pathurlencode($imageobj->getFullImageURL())."</video:content_loc>");
 		$data .= sitemap_echonl("\t\t</video:video>");
 	} else if (in_array($ext,array('.jpg','.jpeg','.gif','.png'))) { // this might need to be extended!
 		$data .= sitemap_echonl("\t\t<image:image>\n\t\t\t<image:loc>".$host.html_encode($imageobj->getSizedImage(getOption('image_size')))."</image:loc>\n");
 		// disabled for the multilingual reasons above
-		$data .= sitemap_echonl("\t\t\t<image:title>".html_encode(get_language_string($imageobj->get('title'),$locale))."</image:title>");
+		$data .= sitemap_echonl("\t\t\t<image:title>".html_encode($imageobj->getTitle($locale))."</image:title>");
 		if ($imageobj->getDesc()) {
-			$data .= sitemap_echonl("\t\t\t<image:caption>".html_encode(strip_tags(get_language_string($imageobj->get('desc'),$locale)))."</image:caption>");
+			$data .= sitemap_echonl("\t\t\t<image:caption>".html_encode(strip_tags($imageobj->getDesc($locale)))."</image:caption>");
 		}
 		if(!empty($license)) {
 			$data .= sitemap_echonl("\t\t\t<image:license>".$license."</image:license>");

--- a/zp-core/zp-extensions/slideshow/slideshow-counter.php
+++ b/zp-core/zp-extensions/slideshow/slideshow-counter.php
@@ -15,7 +15,7 @@ if ($album_name && $img_name ) {
 	$image = newImage($album, $img_name);
 	//update hit counter
 	if (!$album->isMyItem(LIST_RIGHTS)) {
-		$hc = $image->get('hitcounter')+1;
+		$hc = $image->getHitcounter()+1;
 		$image->set('hitcounter', $hc);
 		$image->save();
 	}

--- a/zp-core/zp-extensions/zenpage/admin-edit.php
+++ b/zp-core/zp-extensions/zenpage/admin-edit.php
@@ -404,7 +404,7 @@ if ($result->loaded || $result->transient) {
 			<tr>
 				<td class="topalign-padding"><?php echo gettext("Title:"); ?></td>
 				<td class="middlecolumn">
-					<?php print_language_string_list($result->get('title'), 'title', false, NULL, 'title', '100%', 'zenpage_language_string_list', 10); ?>
+					<?php print_language_string_list($result->getTitle('all'), 'title', false, NULL, 'title', '100%', 'zenpage_language_string_list', 10); ?>
 				</td>
 				<td class="rightcolumn" rowspan="6">
 				<h2 class="h2_bordered_edit"><?php echo gettext("Publish"); ?></h2>
@@ -456,7 +456,7 @@ if ($result->loaded || $result->transient) {
 					<?php
 					}
 					if(get_class($result)=='ZenpagePage' || get_class($result)=='ZenpageCategory' ) {
-						$hint = $result->get('password_hint');
+						$hint = $result->getPasswordHint('all');
 						$user = $result->getUser();
 						$x = $result->getPassword();
 					} else {
@@ -724,9 +724,9 @@ if ($result->loaded || $result->transient) {
 				<td class="middlecolumn">
 					<?php
 					if (is_AdminEditPage("newscategory")) {
-						print_language_string_list($result->get('desc'), 'desc', true, NULL, 'desc', '100%','zenpage_language_string_list',20);
+						print_language_string_list($result->getDesc('all'), 'desc', true, NULL, 'desc', '100%','zenpage_language_string_list',20);
 					} else {
-						print_language_string_list($result->get('content'), 'content', true, NULL, 'content', '100%', 'zenpage_language_string_list', 35);
+						print_language_string_list($result->getContent('all'), 'content', true, NULL, 'content', '100%', 'zenpage_language_string_list', 35);
 					}
 					?>
 				</td>
@@ -738,7 +738,7 @@ if ($result->loaded || $result->transient) {
 					<td class="topalign-padding"><?php echo gettext("ExtraContent:"); ?></td>
 					<td class="middlecolumn">
 						<?php
-							print_language_string_list($result->get('extracontent'), 'extracontent', true, NULL, 'extracontent', '100%', 'zenpage_language_string_list', 10);
+							print_language_string_list($result->getExtraContent('all'), 'extracontent', true, NULL, 'extracontent', '100%', 'zenpage_language_string_list', 10);
 						?>
 					</td>
 				</tr>
@@ -759,7 +759,7 @@ if ($result->loaded || $result->transient) {
 				$custom = zp_apply_filter('edit_page_custom_data', '', $result);
 			}
 			if(empty($custom)) {
-				print_language_string_list($result->get('custom_data'), 'custom_data', true, NULL, 'custom_data', '100%', 'zenpage_language_string_list', 10);
+				print_language_string_list($result->getCustomData('all'), 'custom_data', true, NULL, 'custom_data', '100%', 'zenpage_language_string_list', 10);
 			} else {
 				echo $custom;
 			}

--- a/zp-core/zp-extensions/zenpage/zenpage-class-category.php
+++ b/zp-core/zp-extensions/zenpage/zenpage-class-category.php
@@ -23,7 +23,12 @@ class ZenpageCategory extends ZenpageRoot {
 	 * @return string
 	 */
 	function getDesc($locale=NULL) {
-		return get_language_string($this->get('desc'),$locale);
+		$text = $this->get('desc');
+		if ($locale !=='all') {
+			$text = get_language_string($text,$locale);
+		}
+		$text = zpFunctions::unTagURLs($text);
+		return $text;
 	}
 
 	/**
@@ -31,7 +36,56 @@ class ZenpageCategory extends ZenpageRoot {
 	 *
 	 * @param string $desc description text
 	 */
-	function setDesc($desc) { $this->set('desc', $desc); }
+	function setDesc($desc) {
+		$desc = zpFunctions::tagURLs($desc);
+		$this->set('desc', $desc);
+	}
+
+	/**
+	 * Returns the content
+	 *
+	 * @return string
+	 */
+	function getContent($locale=NULL) {
+		$content = $this->get("content");
+		if ($locale!=='all') {
+			$content = get_language_string($text,$locale);
+		}
+		$content = zpFunctions::unTagURLs($content);
+		return $content;
+	}
+
+	/**
+	 *
+	 * Set the content datum
+	 * @param $c full language string
+	 */
+	function setContent($c) {
+		$c = zpFunctions::tagURLs($c);
+		$this->set("content",$c);
+	}
+
+	/**
+	 * Returns the extra content
+	 *
+	 * @return string
+	 */
+	function getExtraContent($locale=NULL) {
+		$text =  $this->get("extracontent");
+		if ($locale!=='all') {
+			$text = get_language_string($text,$locale);
+		}
+		$text = zpFunctions::unTagURLs($text);
+		return $text;
+	}
+
+	/**
+	 * sets the extra content
+	 *
+	 */
+	function setExtraContent($ec) {
+		$this->set("extracontent",zpFunctions::tagURLs($ec));
+	}
 
 	/**
 	 * Returns the sort order

--- a/zp-core/zp-extensions/zenpage/zenpage-class-page.php
+++ b/zp-core/zp-extensions/zenpage/zenpage-class-page.php
@@ -73,7 +73,12 @@ class ZenpagePage extends ZenpageItems {
 	 * @return string
 	 */
 	function getPasswordHint($locale=NULL) {
-		return get_language_string($this->get('password_hint'),$locale);
+		$text = ($this->get('password_hint'));
+		if ($locale!=='all') {
+			$text = get_language_string($text,$locale);
+		}
+		$text = zpFunctions::unTagURLs($text);
+		return $text;
 	}
 
 	/**
@@ -81,7 +86,9 @@ class ZenpagePage extends ZenpageItems {
 	 *
 	 * @param string $hint the hint text
 	 */
-	function setPasswordHint($hint) { $this->set('password_hint', $hint); }
+	function setPasswordHint($hint) {
+		$this->set('password_hint', zpFunctions::tagURLs($hint));
+	}
 
 	/**
 	 * duplicates an article
@@ -220,7 +227,7 @@ class ZenpagePage extends ZenpageItems {
 		if (empty($hash)) { // no password required
 			return 'zp_public_access';
 		} else {
-			$authType = "zp_page_auth_" . $pageobj->get('id');
+			$authType = "zp_page_auth_" . $pageobj->getID();
 			$saved_auth = zp_getCookie($authType);
 			if ($saved_auth == $hash) {
 				return $authType;

--- a/zp-core/zp-extensions/zenpage/zenpage-class.php
+++ b/zp-core/zp-extensions/zenpage/zenpage-class.php
@@ -892,7 +892,12 @@ class ZenpageItems extends ZenpageRoot {
 	 * @return string
 	 */
 	function getContent($locale=NULL) {
-		return get_language_string($this->get("content"),$locale);
+		$text = $this->get("content");
+		if ($locale!=='all') {
+			$text = get_language_string($text,$locale);
+		}
+		$text = zpFunctions::unTagURLs($text);
+		return $text;
 	}
 
 	/**
@@ -901,6 +906,7 @@ class ZenpageItems extends ZenpageRoot {
 	 * @param $c full language string
 	 */
 	function setContent($c) {
+		$c = zpFunctions::tagURLs($c);
 		$this->set("content",$c);
 	}
 
@@ -967,7 +973,12 @@ class ZenpageItems extends ZenpageRoot {
 	 * @return string
 	 */
 	function getExtraContent($locale=NULL) {
-		return get_language_string($this->get("extracontent"),$locale);
+		$text =  $this->get("extracontent");
+		if ($locale!=='all') {
+			$text = get_language_string($text,$locale);
+		}
+		$text = zpFunctions::unTagURLs($text);
+		return $text;
 	}
 
 	/**
@@ -975,7 +986,7 @@ class ZenpageItems extends ZenpageRoot {
 	 *
 	 */
 	function setExtraContent($ec) {
-		$this->set("extracontent",$ec);
+		$this->set("extracontent",zpFunctions::tagURLs($ec));
 	}
 
 	/**

--- a/zp-core/zp-extensions/zenpage/zenpage-template-functions.php
+++ b/zp-core/zp-extensions/zenpage/zenpage-template-functions.php
@@ -724,7 +724,7 @@ function getNewsVideoContent($imageobj) {
 				$videocontent = '<img src="' . WEBPATH . '/' . ZENFOLDER . '/images/err-noflashplayer.png" alt="'.gettext('No flash player installed.').'" />';
 			} else {
 				$_zp_current_image = $imageobj;
-				$videocontent = $_zp_flash_player->getPlayerConfig(getFullNewsImage(),getNewsTitle(),$_zp_current_image->get("id"));
+				$videocontent = $_zp_flash_player->getPlayerConfig(getFullNewsImage(),getNewsTitle(),$_zp_current_image->getID());
 			}
 			break;
 		case '.3gp':
@@ -1876,8 +1876,8 @@ function getZenpageStatistic($number=10, $option="all",$mode="popular") {
 					"title" => $obj->getTitle(),
 					"titlelink" => $article['titlelink'],
 					"hitcounter" => $obj->getHitcounter(),
-					"total_votes" => $obj->get('total_votes'),
-					"rating" => $obj->get('rating'),
+					"total_votes" => $obj->getTotal_votes(),
+					"rating" => $obj->getRating(),
 					"content" => $obj->getContent(),
 					"date" => $obj->getDateTime(),
 					"type" => "News"
@@ -2449,6 +2449,8 @@ function getBarePageTitle() {
 function printBarePageTitle() {
 	echo html_encode(getBarePageTitle());
 }
+
+/**
  * Returns titlelink of a page
  *
  * @return string
@@ -2840,7 +2842,7 @@ function zenpageOpenedForComments() {
 	if(is_Pages()) {
 		$obj = $_zp_current_zenpage_page;
 	}
-	return $obj->get('commentson');
+	return $obj->getCommentsAllowed();
 }
 
 


### PR DESCRIPTION
GitHub does seem to have issues with branching if the branch gets stale.

This is a re-issue of the changes for portable URLs. This update does
make extensive changes to avoid using the base get and set methods and
use the getxxx, setxxx methods instead.

At some point we may make the base get and set methods private as there
really should be item specific methods, and obviously, the base get and
set methods bypass any object manipulation of the raw data which is
certainy a bad thing.

But for now there are a few places that do not have the appropriate
getxxx setxxx methods, so those get/set calls stay.
