### PR TITLE
Uniform lock distribution and found two existing bugs(not fixed).

### DIFF
--- a/zp-core/functions-basic.php
+++ b/zp-core/functions-basic.php
@@ -1367,8 +1367,8 @@ class Mutex {
 		}
 	}
 
-// returns the integer id of the lock to be obtained
-// rotates locks sequentially mod $concurrent
+	// returns the integer id of the lock to be obtained
+	// rotates locks sequentially mod $concurrent
 	private function which_lock($concurrent) {
 		$path=SERVERPATH.'/'.DATA_FOLDER.'/mutex';
 		if (!file_exists($path)) {
@@ -1380,16 +1380,16 @@ class Mutex {
 			$handle=fopen($counter_file,"w") or $error=true;		
 			fclose($handle);
 		}
-// go atomic:		
+		// go atomic:		
 		$this->lock = 'lock_lock'; 
 		$this->lock();
-// get and increment the lock id:
+		// get and increment the lock id:
 		$count=(int)file_get_contents($counter_file);		
 		$handle=fopen($counter_file,"w") or $error=true;
 		$newcount=($count+1) % $concurrent;
 		fwrite($handle,$newcount) or $error=true;
 		fclose($handle) or $error=true;
-// done with atomic actions.
+		// done with atomic actions.
 		$this->unlock();
 		if($error){ // fall back on a random number.
 			debugLog(sprintf(gettext("Error accessing $counter_file.  Mutex selection failed.  Using random number.")));


### PR DESCRIPTION
Fast and light sequential lock id selection modulo concurrency.

I store the index in a file atomically.
This is MUCH faster than my previous version using getOption/setOption.
On a very old cpu it adds less than 0.5 milliseconds to grabbing the lock.

If file access fails somehow, it falls back on random.

---

.. not that it matters since lock file access probably fails too then, but anyway.

This is integrated into the present Mutex class.

I found two other bugs in the present implementation while testing this.
1 is realted to the options menu not working and another to unlocking errors.

I did NOT fix these because I didn't want to change too much at once (and it turns out I don't understand one of them).  I will report them in separate reports.

In order to test I set the option manually.  I try to test my work, that it at least runs more less.  Of course things can always slip through.

Personally I would not get the lock index in the constructor since it should be obtained as close to locking as possible.  In practice, it's probably irrelevant though, so I tried to change as little as possible basically while getting this feature in.
