### PR TITLE
google maps

### DIFF
--- a/zp-core/functions-basic.php
+++ b/zp-core/functions-basic.php
@@ -805,28 +805,43 @@ function getImageURI($args, $album, $image, $mtime) {
  * @param string $which either 'allowed_tags' or 'style_tags' depending on which is wanted.
  */
 function getAllowedTags($which) {
-	global $_user_tags, $_style_tags;
-	if ($which == 'allowed_tags') {
-		if (is_null($_user_tags)) {
-			$user_tags = "(".getOption('allowed_tags').")";
-			$allowed_tags = parseAllowedTags($user_tags);
-			if ($allowed_tags === false) {  // someone has screwed with the 'allowed_tags' option row in the database, but better safe than sorry
-				$allowed_tags = array();
+	global $_user_tags, $_style_tags, $_default_tags;
+	switch ($which) {
+		case 'allowed_tags':
+			if (is_null($_user_tags)) {
+				$user_tags = "(".getOption('allowed_tags').")";
+				$allowed_tags = parseAllowedTags($user_tags);
+				if ($allowed_tags === false) {  // someone has screwed with the 'allowed_tags' option row in the database, but better safe than sorry
+					$allowed_tags = array();
+				}
+				$_user_tags = $allowed_tags;
 			}
-			$_user_tags = $allowed_tags;
-		}
-		return $_user_tags;
-	} else {
-		if (is_null($_style_tags)) {
-			$style_tags = "(".getOption('style_tags').")";
-			$allowed_tags = parseAllowedTags($style_tags);
-			if ($allowed_tags === false) {  // someone has screwed with the 'style_tags' option row in the database, but better safe than sorry
-				$allowed_tags = array();
+			return $_user_tags;
+			break;
+		case 'style_tags':
+			if (is_null($_style_tags)) {
+				$style_tags = "(".getOption('style_tags').")";
+				$allowed_tags = parseAllowedTags($style_tags);
+				if ($allowed_tags === false) {  // someone has screwed with the 'style_tags' option row in the database, but better safe than sorry
+					$allowed_tags = array();
+				}
+				$_style_tags = $allowed_tags;
 			}
-			$_style_tags = $allowed_tags;
-		}
-		return $_style_tags;
+			return $_style_tags;
+			break;
+		case 'allowed_tags_default':
+			if (is_null($_default_tags)) {
+				$default_tags = "(".getOption('allowed_tags_default').")";
+				$allowed_tags = parseAllowedTags($default_tags);
+				if ($allowed_tags === false) {  // someone has screwed with the 'allowed_tags' option row in the database, but better safe than sorry
+					$allowed_tags = array();
+				}
+				$_default_tags = $allowed_tags;
+			}
+			return $_default_tags;
+			break;
 	}
+	return array();
 }
 
 /**

--- a/zp-core/functions-common.php
+++ b/zp-core/functions-common.php
@@ -162,15 +162,20 @@ function sanitize_string($input_string, $sanitize_level) {
 	if (function_exists('kses')) {
 		switch($sanitize_level) {
 			case 1:
+				// Text formatting sanititation.
 				$allowed_tags = getAllowedTags('allowed_tags');
 				break;
-				// Text formatting sanititation.
 			case 2:
+				// Strips non-style tags.
 				$allowed_tags = getAllowedTags('style_tags');
 				break;
-				// Full sanitation.  Strips all code.
 			case 3:
+				// Full sanitation.  Strips all code.
 				$allowed_tags = array();
+				break;
+			case 4:
+				// for internal use to eliminate security injections
+				$allowed_tags = getAllowedTags('allowed_tags_default');
 				break;
 		}
 		$output_string = kses($input_string, $allowed_tags);

--- a/zp-core/zp-extensions/GoogleMap/m.php
+++ b/zp-core/zp-extensions/GoogleMap/m.php
@@ -67,7 +67,7 @@ header('Last-Modified: ' . gmdate('D, d M Y H:i:s').' GMT');
 	if (is_array($mapdata)) {
 		$MAP_OBJECT = new GoogleMapAPI(sanitize($_GET['type']));
 		foreach ($mapdata as $key=>$datum) {
-			$MAP_OBJECT->$key = sanitize($datum);
+			$MAP_OBJECT->$key = sanitize($datum,4);
 		}
 		$MAP_OBJECT->setJSAlert('<b>Javascript must be enabled in order to use Google Maps.</b>');
 		$MAP_OBJECT->setBrowserAlert('Sorry, the Google Maps API is not compatible with this browser.');


### PR DESCRIPTION
m.php parameter sanitization.
Relax to allow any of the "default" tags in the parameter list. (In
particular, old sanitize was removing the <img src...> tag.
