### PR TITLE
reverts recent changes

### DIFF
--- a/zp-core/zp-extensions/zenpage/zenpage-class-category.php
+++ b/zp-core/zp-extensions/zenpage/zenpage-class-category.php
@@ -323,17 +323,16 @@ class ZenpageCategory extends ZenpageRoot {
 	 * 													"sticky" for sticky articles (published or not!) for Admin page use only,
 	 * 													"all" for all articles
 	 * @param boolean $ignorepagination Since also used for the news loop this function automatically paginates the results if the "page" GET variable is set. To avoid this behaviour if using it directly to get articles set this TRUE (default FALSE)
-	 * @param string $sortorder ,'date' (default),'title', 'popular','mostrated','toprated','random'
+	 * @param string $sortorder "date" for sorting by date (default)
+	 * 													"title" for sorting by title
 	 * 													This parameter is not used for date archives
 	 * @param string $sortdirection "desc" (default) for descending sort order
 	 * 													    "asc" for ascending sort order
-	 *															"none" for no specific sortdirection if using the other sortorderes
 	 * 											        This parameter is not used for date archives
 	 * @param bool $sticky set to true to place "sticky" articles at the front of the list.
-	 * @param integer $threshold the minimum number of ratings an image must have to be included in the list. (Default 0). Only if $sortorder = "mostrated" or "toprated"
 	 * @return array
 	 */
-	function getArticles($articles_per_page=0, $published=NULL,$ignorepagination=false,$sortorder="date", $sortdirection="desc",$sticky=true,$threshold=0) {
+	function getArticles($articles_per_page=0, $published=NULL,$ignorepagination=false,$sortorder="date", $sortdirection="desc",$sticky=true) {
 		global $_zp_current_category, $_zp_post_date;
 		Zenpage::processExpired('news');
 		if (empty($published)) {
@@ -367,24 +366,12 @@ class ZenpageCategory extends ZenpageRoot {
 		}
 		// sortorder and sortdirection
 		switch($sortorder) {
-			case 'date':
+			case "date":
 			default:
-				$sort1 = 'date';
+				$sort1 = "date";
 				break;
-			case 'title':
-				$sort1 = 'title';
-				break;
-			case 'popular':
-				$sort1 = 'hitcounter';
-				break;
-			case 'mostrated':
-				$sort1 = 'total_votes';
-				break;
-			case 'toprated':
-				$sort1 = '(total_value/total_votes) DESC, total_value';
-				break;
-			case 'random':
-				$sort1 = 'RAND()';
+			case "title":
+				$sort1 = "title";
 				break;
 		}
 		switch($sortdirection) {
@@ -394,10 +381,6 @@ class ZenpageCategory extends ZenpageRoot {
 				break;
 			case "asc":
 				$dir = "ASC";
-				$sticky = false;	//makes no sense
-				break;
-			case "none":
-				$dir = "";
 				$sticky = false;	//makes no sense
 				break;
 		}
@@ -423,11 +406,6 @@ class ZenpageCategory extends ZenpageRoot {
 				$getUnpublished = true;
 				$show = "";
 				break;
-		}
-		if($sort1 == 'mostrated' || $sort1 == 'toprated') {
-			if ($threshold > 0) {
-			$show  .= ' AND news.total_votes >= '.$threshold;
-			}
 		}
 		$order = " ORDER BY ".$sticky."news.$sort1 $dir";
 		$sql = "SELECT DISTINCT news.date, news.title, news.titlelink FROM ".prefix('news')." as news, ".prefix('news2cat')." as cat WHERE".$cat.$show.$order;

--- a/zp-core/zp-extensions/zenpage/zenpage-template-functions.php
+++ b/zp-core/zp-extensions/zenpage/zenpage-template-functions.php
@@ -1843,11 +1843,10 @@ function printPrevNewsLink($prev="« ",$sortorder='date',$sortdirection='desc') 
  * 										 "mostrated" for news articles and pages
  * 										 "toprated" for news articles and pages
  * 										 "random" for pages, news articles and categories
- * @param integer $threshold the minimum number of ratings an image must have to be included in the list. (Default 0). Only if $sortorder = "mostrated" or "toprated"
  * @return array
  */
-function getZenpageStatistic($number=10, $option="all",$mode="popular",$threshold=0) {
-	global $_zp_zenpage, $_zp_current_zenpage_news, $_zp_current_zenpage_pages;
+function getZenpageStatistic($number=10, $option="all",$mode="popular") {
+	global $_zp_current_zenpage_news, $_zp_current_zenpage_pages;
 	$statsarticles = array();
 	$statscats = array();
 	$statspages = array();
@@ -1866,7 +1865,7 @@ function getZenpageStatistic($number=10, $option="all",$mode="popular",$threshol
 			break;
 		}
 	if($option == "all" OR $option == "news") {
-		$articles = $_zp_zenpage->getArticles($number,NULL,true,$mode,NULL,false,$threshold);
+		$articles = query_full_array("SELECT titlelink FROM " . prefix('news')." ORDER BY $sortorder DESC LIMIT $number");
 		$counter = "";
 		$statsarticles = array();
 		foreach ($articles as $article) {
@@ -1877,8 +1876,8 @@ function getZenpageStatistic($number=10, $option="all",$mode="popular",$threshol
 					"title" => $obj->getTitle(),
 					"titlelink" => $article['titlelink'],
 					"hitcounter" => $obj->getHitcounter(),
-					"total_votes" => $obj->get('total_votes'),
-					"rating" => $obj->get('rating'),
+					"total_votes" => $obj->getTotal_votes(),
+					"rating" => $obj->getRating(),
 					"content" => $obj->getContent(),
 					"date" => $obj->getDateTime(),
 					"type" => "News"
@@ -1887,7 +1886,7 @@ function getZenpageStatistic($number=10, $option="all",$mode="popular",$threshol
 		$stats = $statsarticles;
 	}
 	if(($option == "all" OR $option == "categories") && $mode != "mostrated" && $mode != "toprated") {
-		$categories = $_zp_zenpage->getCategories(NULL,false,$mode,NULL,$number);
+		$categories = query_full_array("SELECT id, titlelink as title, title as titlelink, hitcounter FROM " . prefix('news_categories')." ORDER BY $sortorder DESC LIMIT $number");
 		$counter = "";
 		$statscats = array();
 		foreach ($categories as $cat) {
@@ -1907,7 +1906,7 @@ function getZenpageStatistic($number=10, $option="all",$mode="popular",$threshol
 		$stats = $statscats;
 	}
 	if($option == "all" OR $option == "pages") {
-		$pages = $_zp_zenpage->getPages(NULL,false,$mode,'',$number,$threshold);
+		$pages = query_full_array("SELECT titlelink FROM " . prefix('pages')." ORDER BY $sortorder DESC LIMIT $number");
 		$counter = "";
 		$statspages = array();
 		foreach ($pages as $page) {
@@ -1950,10 +1949,9 @@ function getZenpageStatistic($number=10, $option="all",$mode="popular",$threshol
  * @param bool $showdate if the date should be shown (news articles and pages only)
  * @param bool $showcontent if the content should be shown (news articles and pages only)
  * @param bool $contentlength The shortened lenght of the content
- * @param integer $threshold the minimum number of ratings an image must have to be included in the list. (Default 0). Only if $sortorder = "mostrated" or "toprated"
  */
-function printZenpageStatistic($number=10, $option="all",$mode="popular",$showstats=true,$showtype=true, $showdate=true, $showcontent=true, $contentlength=40,$threshold=0) {
-	$stats = getZenpageStatistic($number, $option,$mode,$threshold);
+function printZenpageStatistic($number=10, $option="all",$mode="popular",$showstats=true,$showtype=true, $showdate=true, $showcontent=true, $contentlength=40) {
+	$stats = getZenpageStatistic($number, $option,$mode);
 	$contentlength = sanitize_numeric($contentlength);
 	switch($mode) {
 		case 'popular':
@@ -3020,11 +3018,6 @@ function getZenpageRSSLink($option='News', $categorylink='', $lang=NULL) {
 		case 'NewsWithImages':
 			if (getOption('RSS_articles')) {
 				return WEBPATH.'/index.php?rss=news&withimages&lang='.$lang;
-			}
-			break;
-		case 'Pages':
-			if (getOption('RSS_pages')) {
-				return WEBPATH.'/index.php?rss=pages&lang='.$lang;
 			}
 			break;
 		case 'Comments':


### PR DESCRIPTION
Note: the database table structure for categories and pages is liniar
while the object structure is hierarchical. This means that it is at
best impractical to use SQL queries to retrieve "published" items
because the item's parent may not be published.

So, for instance, for categories it is needed to have the master
category list include ALL categories to enable the fetch code to test to
be sure that a category does not reside in an unpublished parent (which
implies that the item is not published even if it is marked published.)

The original code did do this processing and any revision MUST take the
hierarchy into consideration.
