### PR TITLE
Setup to detect Suhosin

### DIFF
--- a/zp-core/global-definitions.php
+++ b/zp-core/global-definitions.php
@@ -19,6 +19,7 @@ define('ADMIN_PLUGIN',2048);
 define('THEME_PLUGIN',1024);
 define('PLUGIN_PRIORITY',1023);
 
+define('SYMLINK',function_exists('symlink') && strpos(@ini_get("suhosin.executor.func.blacklist"),'symlink')===false);
 define('TEST_RELEASE',strpos(ZENPHOTO_VERSION, '-')!==false);
 
 define('DEBUG_LOGIN', false); // set to true to log admin saves and login attempts

--- a/zp-core/setup/index.php
+++ b/zp-core/setup/index.php
@@ -523,6 +523,26 @@ if ($connection && $_zp_loggedin != ADMIN_RIGHTS) {
 	}
 	checkMark($safe, gettext("PHP <code>Safe Mode</code>"), gettext("PHP <code>Safe Mode</code> [is set]"), gettext("Zenphoto functionality is reduced when PHP <code>safe mode</code> restrictions are in effect."));
 
+	if (!extension_loaded('suhosin')) {
+		$blacklist = @ini_get("suhosin.executor.func.blacklist");
+		if ($blacklist) {
+			$zpUses = array('symlink'=>0);
+			$abort = $issue = 0;
+			$blacklist = explode(',', $blacklist);
+			foreach ($blacklist as $key=>$func) {
+				if (array_key_exists($func, $zpUses)) {
+					$abort = true;
+					$issue = $issue | $zpUses[$func];
+					if ($zpUses[$func]) {
+						$blacklist[$key] = '<span style="color:red;">'.$func.'*</span>';
+					}
+				}
+			}
+			$issue--;
+			$good = checkMark($issue, '',gettext('<code>Suhosin</code> module [is enabled]'),sprintf(gettext('The following PHP functions are blocked: %s. Flagged functions are required by Zenphoto. Other functions in the list may be used by Zenphoto, possibly causing reduced functionality or Zenphoto failures.'),'<code>'.implode('</code>, <code>',$blacklist).'</code>'),$abort) && $good;
+		}
+	}
+
 	primeMark(gettext('Magic_quotes'));
 	if (get_magic_quotes_gpc()) {
 		$magic_quotes_disabled = -1;


### PR DESCRIPTION
Setup will detect the suhosin module and warn/error if we know Zenphoto
uses blacklisted functions. Note, the list of functions is manually
determined. At present all we know is about symlink().
