### PR TITLE
Fix mod_rewrite dynamic album image handling when not using a rewrite suffix (issue #447)

### DIFF
--- a/zp-core/functions-basic.php
+++ b/zp-core/functions-basic.php
@@ -508,10 +508,22 @@ function rewrite_get_album_image($albumvar, $imagevar) {
 						$rimage = basename($ralbum);
 						$ralbum = trim(dirname($ralbum),'/');
 					}
+				} else if (file_exists($path.'.alb')) {
+					//	it is a dynamic album sans suffix
+					$ralbum .= '.alb';
 				} else {
-					if (file_exists($path.'.alb')) {
-						//	it is a dynamic album sans suffix
-						$ralbum .= '.alb';
+					//	Perhaps a dynamicalbum/image 
+					$rimage = basename($ralbum);
+					$ralbum = trim(dirname($ralbum),'/');
+					$path = internalToFilesystem(getAlbumFolder(SERVERPATH).$ralbum);
+
+					if (!is_dir($path)) {
+
+						if (file_exists($path.'.alb')) {
+
+							//	it is a dynamic album sans suffix
+							$ralbum .= '.alb';
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Dynamic album images with the mod_rewrite option turned on _without_ a
mod_rewrite suffix added weren't working: the target image link of
DYNAMIC/IMAGE didn't work because only 'DYNAMIC/IMAGE.alb' was checked
for existance, but 'DYNAMIC.alb' needs to be checked as well.
