### PR TITLE
Update functions-image.php

### DIFF
--- a/zp-core/functions-image.php
+++ b/zp-core/functions-image.php
@@ -174,7 +174,7 @@ function cacheImage($newfilename, $imgfile, $args, $allow_watermark = false, $th
 			$rotate = getImageRotation($imgfile);
 		}
 		$s = getSuffix($imgfile);
-		if (function_exists('exif_thumbnail') && getOption('use_embedded_thumb') && ($s == 'jpg') || $s == 'jpeg') {
+		if (function_exists('exif_thumbnail') && getOption('use_embedded_thumb') && ($s == 'jpg' || $s == 'jpeg')) {
 			$im = exif_thumbnail($imgfile, $tw, $th, $tt);
 			if ($im) {
 				if ($size) {


### PR DESCRIPTION
Misplaced parenthesis causes option 'use_embedded_thumb' setting to be ignored in case ($s='jpeg') and forces 'exif_thumbnail()' function to be used for thumbnail generation. Function call fails if EXIF module is not loaded.
