### PR TITLE
Fix a bug with i.php no longer handling thumb size

### DIFF
--- a/zp-core/functions-basic.php
+++ b/zp-core/functions-basic.php
@@ -709,14 +709,6 @@ function getImageParameters($args, $album = NULL) {
 	$thumb = $thumbstandin;
 
 	switch ($size) {
-		case 0:
-		default:
-			if (empty($size) || !is_numeric($size)) {
-				$size = false; // 0 isn't a valid size anyway, so this is OK.
-			} else {
-				$size = round($size);
-			}
-			break;
 		case 'thumb':
 			$thumb = true;
 			if ($thumb_crop) {
@@ -727,6 +719,14 @@ function getImageParameters($args, $album = NULL) {
 			break;
 		case 'default':
 			$size = $image_default_size;
+			break;
+		case 0:
+		default:
+			if (empty($size) || !is_numeric($size)) {
+				$size = false; // 0 isn't a valid size anyway, so this is OK.
+			} else {
+				$size = round($size);
+			}
 			break;
 	}
 


### PR DESCRIPTION
I think is was introduced at c26d2794f01d4fca9c1f0699311323f1c3beebcd.

Anyway, the default case should be last, also the 0 case seams to match a string in php...
