### PR TITLE
Slideshow1 comments clarification

### DIFF
--- a/zp-core/zp-extensions/slideshow.php
+++ b/zp-core/zp-extensions/slideshow.php
@@ -10,10 +10,13 @@
  * 		<li>Plugin Option 'slideshow_showdesc' -- Allows the show to display image descriptions</li>
  * 	</ul>
  *
- * The theme files <var>slideshow.php</var>, <var>slideshow.css</var>, and <var>slideshow-controls.png</var> must reside in the theme
- * folder. If you are creating a custom theme, copy these files form the "default" theme of the Zenphoto
- * distribution. Note that the Colorbox mode does not require these files as it is called on your theme's image.php and album.php direclty
- * via the slideshow button. The Colorbox plugin must be enabled and setup for these pages.
+ * For the jQuery Cycle mode, the theme file <var>slideshow.php</var> must reside in the theme
+ * folder. If you are creating a custom theme, copy this file from an included theme of the Zenphoto
+ * distribution. A custom theme css file <var>slideshow.css</var> will be loaded from the theme
+ * folder, if not present, a default css file in the plugin folder will be loaded.  
+ *
+ * Note that the Colorbox mode does not require these files as it is called on your theme's image.php, album.php, 
+ * search.php, and favorites.php (if enabled) directly via the slideshow button. The Colorbox plugin must be enabled and setup for these pages.
  *
  * <b>NOTE:</b> The jQuery Cycle and the jQuery Colorbox modes do not support movie and audio files.
  * In Colorbox mode there will be no slideshow button on the image page if that current image is a movie/audio file.


### PR DESCRIPTION
Just a change in the comments.  New themes are not required to include
slideshoww.css or controls if they do not want to customize, because
they will be pulled from the plugin folder if absent.
