### PR TITLE
Fixed the logic of detecting login success; fix zp_handle_password

### DIFF
--- a/zp-core/functions.php
+++ b/zp-core/functions.php
@@ -1684,13 +1684,14 @@ function zp_handle_password($authType = NULL, $check_auth = NULL, $check_user = 
 	// Handle the login form.
 	if (DEBUG_LOGIN)
 		debugLog("zp_handle_password: \$authType=$authType; \$check_auth=$check_auth; \$check_user=$check_user; ");
+
 	if (isset($_POST['password']) && isset($_POST['pass'])) { // process login form
 		if (isset($_POST['user'])) {
 			$post_user = sanitize($_POST['user']);
 		} else {
 			$post_user = '';
 		}
-		$post_pass = sanitize($_POST['pass']);
+		$post_pass = $_POST['pass']; // We should not sanitize the password
 
 		foreach (Zenphoto_Authority::$hashList as $hash => $hi) {
 			$auth = Zenphoto_Authority::passwordHash($post_user, $post_pass, $hi);

--- a/zp-core/zp-extensions/downloadList.php
+++ b/zp-core/zp-extensions/downloadList.php
@@ -599,7 +599,7 @@ if (isset($_GET['download'])) {
     //	credentials required to download
     $user = getOption('downloadList_user');
     zp_handle_password('download_auth', $hash, $user);
-    if ((!empty($hash) && zp_getCookie('download_auth') != $hash) || !zp_loggedin((getOption('downloadList_rights')) ? FILES_RIGHTS : ALL_RIGHTS)) {
+    if ((!empty($hash) && zp_getCookie('download_auth') != $hash) && !zp_loggedin((getOption('downloadList_rights')) ? FILES_RIGHTS : ALL_RIGHTS)) {
       $show = ($user) ? true : NULL;
       $hint = '';
       if (!empty($hash)) {
@@ -647,4 +647,4 @@ if (isset($_GET['download'])) {
     }
   }
 }
-    ?>
+?>


### PR DESCRIPTION
The bug was caused just by the use of `||` instead of `&&`, but in addition, I've resolved the issue that we should never sanitize the password, since the only thing done with it is hashing it to oblivion immediately thereafter. Sanitization could incorrectly dispose of special characters that should be valid in a password.
