### PR TITLE
Don't sanitize mysql password when updating from setup

### DIFF
--- a/zp-core/functions-db-MySQLi.php
+++ b/zp-core/functions-db-MySQLi.php
@@ -11,8 +11,8 @@
 // force UTF-8 Ø
 
 define('DATABASE_SOFTWARE', 'MySQLi');
-Define('DATABASE_MIN_VERSION', '5.0.0');
-Define('DATABASE_DESIRED_VERSION', '5.5.0');
+define('DATABASE_MIN_VERSION', '5.0.0');
+define('DATABASE_DESIRED_VERSION', '5.5.0');
 
 /**
  * Connect to the database server and select the database.

--- a/zp-core/setup/index.php
+++ b/zp-core/setup/index.php
@@ -157,13 +157,13 @@ if (isset($_POST['db'])) { //try to update the zp-config file
 		$zp_cfg = updateConfigItem('db_software', setup_sanitize($_POST['db_software']), $zp_cfg);
 	}
 	if (isset($_POST['db_user'])) {
-		$zp_cfg = updateConfigItem('mysql_user', setup_sanitize($_POST['db_user']), $zp_cfg);
+		$zp_cfg = updateConfigItem('mysql_user', setup_sanitize($_POST['db_user'], 0), $zp_cfg);
 	}
 	if (isset($_POST['db_pass'])) {
-		$zp_cfg = updateConfigItem('mysql_pass', setup_sanitize($_POST['db_pass']), $zp_cfg);
+		$zp_cfg = updateConfigItem('mysql_pass', setup_sanitize($_POST['db_pass'], 0), $zp_cfg);
 	}
 	if (isset($_POST['db_host'])) {
-		$zp_cfg = updateConfigItem('mysql_host', setup_sanitize($_POST['db_host']), $zp_cfg);
+		$zp_cfg = updateConfigItem('mysql_host', setup_sanitize($_POST['db_host'], 0), $zp_cfg);
 	}
 	if (isset($_POST['db_database'])) {
 		$zp_cfg = updateConfigItem('mysql_database', trim(setup_sanitize($_POST['db_database'])), $zp_cfg);


### PR DESCRIPTION
Or any of the other mysql configuration items for that matter... it's irrelevant if HTML tags or characters make their way into these config vars.

Fixes #842
