### PR TITLE
Fix automatic cache rebuild

### DIFF
--- a/zp-core/404.php
+++ b/zp-core/404.php
@@ -8,7 +8,7 @@ if (array_key_exists(0, $folders) && $folders[0] == CACHEFOLDER) {
 	require_once(SERVERPATH . '/' . ZENFOLDER . '/admin-functions.php');
 	require_once(SERVERPATH . '/' . ZENFOLDER . '/' . PLUGIN_FOLDER . '/cacheManager/functions.php');
 	unset($folders[0]);
-	list($image, $args) = getImageProcessorURIFromCacheName(implode('/', $folders), getWatermarks());
+	list($image, $args) = getImageProcessorURIFromCacheName(implode('/', $folders).'/'.$image, getWatermarks());
 	if (file_exists(getAlbumFolder() . $image)) {
 		$uri = getImageURI($args, dirname($image), basename($image), NULL);
 		header("HTTP/1.0 302 Found");


### PR DESCRIPTION
If a requested image is not found in the cache, there appears to be code in place to try and generate the image on the fly.

However, this code is broken, as the name of the image file is not included in the call to getImageProcessorURIFromCacheName() (only the path to the image is included).

Adding:
'/'.$image
 to the end of the path seems to work.

I haven't been able to determine if there are any limits to stop a user filling up all the space on the server by repeatedly requesting images at 1-pixel increments (which wouldn't be a problem without this fix, as it would just give an error).