### PR TITLE
Fix issue 906 - unclosed <div>

### DIFF
--- a/zp-core/template-functions.php
+++ b/zp-core/template-functions.php
@@ -323,7 +323,8 @@ function adminToolbox() {
 					?>
 				</ul>
 			</div>
-			<?php
+		</div>
+		<?php
 		}
 	}
 }


### PR DESCRIPTION
The admin menu in version 1.4.7 generates invalid HTML, which breaks some themes. Ensure that all div elements are closed.