### PR TITLE
Fixed the position of tag suggestions

### DIFF
--- a/zp-core/admin-functions.php
+++ b/zp-core/admin-functions.php
@@ -1115,7 +1115,9 @@ function printAdminHeader($tab, $subtab = NULL) {
 				<a href="javascript:addNewTag('<?php echo $postit; ?>');" title="<?php echo gettext('add tag'); ?>">
 					<img src="images/add.png" title="<?php echo gettext('add tag'); ?>"/>
 				</a>
-				<input class="tagsuggest <?php echo $class; ?> " type="text" value="" name="newtag_<?php echo $postit; ?>" id="newtag_<?php echo $postit; ?>" />
+				<span class="tagSuggestContainer">
+					<input class="tagsuggest <?php echo $class; ?> " type="text" value="" name="newtag_<?php echo $postit; ?>" id="newtag_<?php echo $postit; ?>" />
+				</span>
 			</span>
 
 			<?php
@@ -1461,7 +1463,9 @@ function printAdminHeader($tab, $subtab = NULL) {
 								<span id="album_custom_div<?php echo $suffix; ?>" class="customText" style="display:<?php echo $dsp; ?>;white-space:nowrap;">
 									<br />
 									<?php echo gettext('custom fields:') ?>
-									<input id="customalbumsort<?php echo $suffix; ?>" class="customalbumsort" name="<?php echo $prefix; ?>customalbumsort" type="text" value="<?php echo html_encode($cvt); ?>" />
+									<span class="tagSuggestContainer">
+										<input id="customalbumsort<?php echo $suffix; ?>" class="customalbumsort" name="<?php echo $prefix; ?>customalbumsort" type="text" value="<?php echo html_encode($cvt); ?>" />
+									</span>
 								</span>
 							</td>
 						</tr>
@@ -1517,7 +1521,9 @@ function printAdminHeader($tab, $subtab = NULL) {
 								<span id="image_custom_div<?php echo $suffix; ?>" class="customText" style="display:<?php echo $dsp; ?>;white-space:nowrap;">
 									<br />
 									<?php echo gettext('custom fields:') ?>
-									<input id="customimagesort<?php echo $suffix; ?>" class="customimagesort" name="<?php echo $prefix; ?>customimagesort" type="text" value="<?php echo html_encode($cvt); ?>" />
+									<span class="tagSuggestContainer">
+										<input id="customimagesort<?php echo $suffix; ?>" class="customimagesort" name="<?php echo $prefix; ?>customimagesort" type="text" value="<?php echo html_encode($cvt); ?>" />
+									</span>
 								</span>
 							</td>
 						</tr>

--- a/zp-core/admin-options.php
+++ b/zp-core/admin-options.php
@@ -1296,7 +1296,9 @@ Zenphoto_Authority::printPasswordFormJS();
 												<td colspan="2">
 													<span id="customTextBox2" class="customText" style="display:<?php echo $dspc; ?>">
 														<?php echo gettext('custom fields:') ?>
-														<input id="customalbumsort" name="customalbumsort" type="text" value="<?php echo html_encode($cvt); ?>" />
+														<span class="tagSuggestContainer">
+															<input id="customalbumsort" name="customalbumsort" type="text" value="<?php echo html_encode($cvt); ?>" />
+														</span>
 													</span>
 												</td>
 											</tr>
@@ -1680,7 +1682,9 @@ Zenphoto_Authority::printPasswordFormJS();
 										<span id="album_custom_div" class="customText" style="display:<?php echo $dsp; ?>;white-space:nowrap;">
 											<br />
 											<?php echo gettext('custom fields:') ?>
-											<input id="customalbumsort" class="customalbumsort" name="customalbumsort" type="text" value="<?php echo html_encode($cvt); ?>" />
+											<span class="tagSuggestContainer">
+												<input id="customalbumsort" class="customalbumsort" name="customalbumsort" type="text" value="<?php echo html_encode($cvt); ?>" />
+											</span>
 										</span>
 									</td>
 
@@ -1729,7 +1733,9 @@ Zenphoto_Authority::printPasswordFormJS();
 										<span id="image_custom_div" class="customText" style="display:<?php echo $dsp; ?>;white-space:nowrap;">
 											<br />
 											<?php echo gettext('custom fields:') ?>
-											<input id="customimagesort" class="customimagesort" name="customimagesort" type="text" value="<?php echo html_encode($cvt); ?>" />
+											<span class="tagSuggestContainer">
+												<input id="customimagesort" class="customimagesort" name="customimagesort" type="text" value="<?php echo html_encode($cvt); ?>" />
+											</span>
 										</span>
 									</td>
 
@@ -1817,7 +1823,9 @@ Zenphoto_Authority::printPasswordFormJS();
 										<span id="customTextBox3" class="customText" style="display:<?php echo $dspc; ?>">
 											<br />
 											<?php echo gettext('custom fields:') ?>
-											<input id="customimagesort" name="customimagesort" type="text" value="<?php echo html_encode($cvt); ?>" />
+											<span class="tagSuggestContainer">
+												<input id="customimagesort" name="customimagesort" type="text" value="<?php echo html_encode($cvt); ?>" />
+											</span>
 										</span>
 
 									</td>

--- a/zp-core/template-functions.php
+++ b/zp-core/template-functions.php
@@ -3919,7 +3919,9 @@ function printSearchForm($prevtext = NULL, $id = 'search', $buttonSource = NULL,
 			</script>
 			<?php echo $prevtext; ?>
 			<div>
-				<input type="text" name="words" value="" id="search_input" size="10" />
+				<span class="tagSuggestContainer">
+					<input type="text" name="words" value="" id="search_input" size="10" />
+				</span>
 				<?php if (count($fields) > 1 || $searchwords) { ?>
 					<a href="javascript:toggle('searchextrashow');" ><img src="<?php echo $iconsource; ?>" title="<?php echo gettext('search options'); ?>" alt="<?php echo gettext('fields'); ?>" id="searchfields_icon" /></a>
 				<?php } ?>

--- a/zp-core/zp-extensions/favoritesHandler/favoritesClass.php
+++ b/zp-core/zp-extensions/favoritesHandler/favoritesClass.php
@@ -327,7 +327,9 @@ class favorites extends AlbumBase {
 			if ($v) {
 				if ($multi) {
 					?>
-					<input type="text" name="instance" class="favorite_instance" value="" />
+					<span class="tagSuggestContainer">
+						<input type="text" name="instance" class="favorite_instance" value="" />
+					</span>
 					<?php
 				}
 			} else {

--- a/zp-core/zp-extensions/tag_suggest/tag.css
+++ b/zp-core/zp-extensions/tag_suggest/tag.css
@@ -6,6 +6,8 @@ span.tagMatches {
 	text-align: left;
 	overflow: auto;
 	border: 0;
+	top: 19px;
+	left: 0;
 } 
     
 span.tagMatches span { 
@@ -17,4 +19,8 @@ span.tagMatches span {
 
 ._tag_suggestion {
 	float: left; 
+}
+
+.tagSuggestContainer {
+	position: relative;
 }


### PR DESCRIPTION
On a fresh install of the latest master I noticed that tag suggestions were appearing to the right of input boxes instead of underneath, which also meant two clicks were needed - the first one moved the box to under the input box (weird behavior). This fixes both issues.