### PR TITLE
Zenphoto Issue #936, getNotViewableImages uses a wrong clause when determining which images should be hidden

### DIFF
--- a/zp-core/functions.php
+++ b/zp-core/functions.php
@@ -1550,7 +1550,7 @@ function getNotViewableImages() {
     }
   }
   if (is_null($_zp_not_viewable_image_list)) {
-    $sql = 'SELECT `id` FROM ' . prefix('images') . ' WHERE `show`= 0' . $where;
+    $sql = 'SELECT DISTINCT `id` FROM (SELECT `id` FROM ' . prefix('images') . ' WHERE `show`= 0 UNION SELECT `id` FROM ' . prefix('images') . ' WHERE (`show` = 1 ' . $where . ')) as tbl';
     $result = query($sql);
     if ($result) {
       $_zp_not_viewable_image_list = array();


### PR DESCRIPTION
Created a issue: https://github.com/zenphoto/zenphoto/issues/936

getNotViewableImages uses a wrong clause when determining which images
should be hidden. It checks for show = 0 and albumid = #. This
doesn't exclude the images which have show =1 but are contained in
albums the user doesn't have access to. This makes the printAllTagsAs(
with checkAccess = true) print the wrong count as it will count all
items with the tag but not exclude the items the user doesn't have
access to.