### PR TITLE
getNotViewableImages uses a wrong clause when determining which images should be hidden

### DIFF
--- a/zp-core/functions.php
+++ b/zp-core/functions.php
@@ -1548,7 +1548,7 @@ function getNotViewableImages() {
     $where = implode(',', $hidealbums);
   }
   if (is_null($_zp_not_viewable_image_list)) {
-    $sql = 'SELECT DISTINCT `id` FROM ' . prefix('images') . ' WHERE `show` = 0 OR `albumId` in (' . $where . ')';
+    $sql = 'SELECT DISTINCT `id` FROM ' . prefix('images') . ' WHERE `show` = 0 OR `albumid` in (' . $where . ')';
     $result = query($sql);
     if ($result) {
       $_zp_not_viewable_image_list = array();

--- a/zp-core/functions.php
+++ b/zp-core/functions.php
@@ -1545,12 +1545,10 @@ function getNotViewableImages() {
   $hidealbums = getNotViewableAlbums();
   $where = '';
   if (!is_null($hidealbums)) {
-    foreach ($hidealbums as $id) {
-      $where .= ' AND `albumid` = ' . $id;
-    }
+    $where = implode(',', $hidealbums);
   }
   if (is_null($_zp_not_viewable_image_list)) {
-    $sql = 'SELECT `id` FROM ' . prefix('images') . ' WHERE `show`= 0' . $where;
+    $sql = 'SELECT DISTINCT `id` FROM ' . prefix('images') . ' WHERE `show` = 0 OR `albumId` in (' . $where . ')';
     $result = query($sql);
     if ($result) {
       $_zp_not_viewable_image_list = array();


### PR DESCRIPTION
getNotViewableImages uses a wrong clause when determining which images
should be hidden. It checks for show = 0 and albumid = #. This doesn't
exclude the images which have show =1 but are contained in albums the
user doesn't have access to. This makes the printAllTagsAs(with
checkAccess = true) print the wrong count as it will count all items
with the tag but not exclude the items the user doesn't have access to.

The query is trying to come up with a list of images that need to be hidden. Fix is to exclude items marked show = 0 and also the ones that are present in albums the user doesn't have access to.