### PR TITLE
getAllTagsCount called with checkaccess = true prints debug spew

### DIFF
--- a/zp-core/functions.php
+++ b/zp-core/functions.php
@@ -1142,7 +1142,6 @@ function getAllTagsCount($exclude_unassigned = false, $checkaccess = false) {
       if($checkaccess) {
         $count = getTagCountByAccess($tag);
         if($count != 0) {
-          echo $tag['name']." included<br>";
           $_zp_count_tags[$tag['name']] = $count;
         }
       } else {


### PR DESCRIPTION
The method returns an array, it shouldn't be printing html content.