### PR TITLE
fix rel attribute on <a> tag

### DIFF
--- a/zp-core/setup/setup-option-defaults.php
+++ b/zp-core/setup/setup-option-defaults.php
@@ -131,17 +131,17 @@ setOptionDefault('hotlink_protection', '1');
 
 setOptionDefault('search_fields', 'title,desc,tags,file,location,city,state,country,content,author');
 
-$a = "a => (href =>() title =>() target=>() class=>() id=>())\n" .
+$a = "a => (href =>() title =>() target=>() class=>() id=>() rel=>())\n" .
 				"abbr =>(class=>() id=>() title =>())\n" .
 				"acronym =>(class=>() id=>() title =>())\n" .
 				"b => (class=>() id=>() )\n" .
 				"blockquote =>(class=>() id=>() cite =>())\n" .
-				"br => (class=>() id=>() )\n" .
-				"code => (class=>() id=>() )\n" .
-				"em => (class=>() id=>() )\n" .
-				"i => (class=>() id=>() ) \n" .
-				"strike => (class=>() id=>() )\n" .
-				"strong => (class=>() id=>() )\n" .
+				"br => (class=>() id=>())\n" .
+				"code => (class=>() id=>())\n" .
+				"em => (class=>() id=>())\n" .
+				"i => (class=>() id=>()) \n" .
+				"strike => (class=>() id=>())\n" .
+				"strong => (class=>() id=>())\n" .
 				"ul => (class=>() id=>())\n" .
 				"ol => (class=>() id=>())\n" .
 				"li => (class=>() id=>())\n" .
@@ -157,7 +157,7 @@ $a = "a => (href =>() title =>() target=>() class=>() id=>())\n" .
 				"span=>(class=>() id=>() style=>())\n" .
 				"div=>(class=>() id=>() style=>())\n" .
 				"img=>(class=>() id=>() style=>() src=>() title=>() alt=>() width=>() height=>())\n" .
-				"iframe=>(class=>() id=>() style=>() src=>() title=>() width=>() height=>() frameborder=>())\n"
+				"iframe=>(class=>() id=>() style=>() src=>() title=>() width=>() height=>())\n"
 ;
 setOption('allowed_tags_default', $a);
 setOptionDefault('allowed_tags', $a);


### PR DESCRIPTION
rel attribute is used by tinyMCE, but not allowed by default by zenphoto so it is filtered.

also fix typo and an older discus about frameborder attribute on iframe (not supported by html5 as marginwidth, marginheight and scrolling attributes
(https://github.com/zenphoto/zenphoto/commit/96b8beae38bb34e3275ed888b41b4c1463d54b3a)