### PR TITLE
Loading cookieconsent JS at document bottom

### DIFF
--- a/zp-core/zp-extensions/cookieconsent.php
+++ b/zp-core/zp-extensions/cookieconsent.php
@@ -18,8 +18,8 @@ $plugin_category = gettext('Misc');
 
 if (!isset($_COOKIE['cookieconsent_status'])) {
 	zp_register_filter('theme_head', 'cookieConsent::getCSS');
-	zp_register_filter('theme_head', 'cookieConsent::getJS');
-}	
+	zp_register_filter('theme_body_close', 'cookieConsent::getJS');
+}
 class cookieConsent {
 
 	function __construct() {
@@ -104,7 +104,7 @@ class cookieConsent {
 						'type' => OPTION_TYPE_COLOR_PICKER,
 						'order' => 11,
 						'desc' => gettext('Choose the color of the button.'))
-				
+
 		);
 		return $options;
 	}


### PR DESCRIPTION
For performance reasons and also because cookieconsent script is not loading at all on my local server if in theme_head, without a a MIME type declaration. I'm not sure if it really needs to be in theme_head for other reasons that I'm not getting, in that case just reject this pull request and forgive me :)

PS
I see changes I didn't make, I just changed line 21 in Atom editor.