### PR TITLE
removed orphan closing php tag

### DIFF
--- a/zp-core/utilities/list_locales.php
+++ b/zp-core/utilities/list_locales.php
@@ -100,4 +100,3 @@ printAdminHeader('overview', 'List locales');
 	<?php printAdminFooter(); ?>
 </body>
 </html>
-?>


### PR DESCRIPTION
leading to a `?>` displayed at the end of `list_locales.php` page.

![locale](https://user-images.githubusercontent.com/2939831/56458155-72d5f180-6383-11e9-9329-575088c5f85a.jpg)
