### PR TITLE
Fix missing width and height in album thumbs

### DIFF
--- a/zp-core/template-functions.php
+++ b/zp-core/template-functions.php
@@ -1898,7 +1898,7 @@ function printCustomAlbumThumbImage($alt, $size, $width = NULL, $height = NULL, 
 	}
 	$class = trim($class);
 	/* set the HTML image width and height parameters in case this image was "imageDefault.png" substituted for no thumbnail then the thumb layout is preserved */
-	$sizes = getSizeCustomImage($size, $width, $height, $cropw, $croph, $cropx, $cropy);
+	$sizes = getSizeCustomImage($size, $width, $height, $cropw, $croph, $cropx, $cropy, $_zp_current_album->getAlbumThumbImage());
 	$sizing = ' width="' . $sizes[0] . '" height="' . $sizes[1] . '"';
 	if($class) {
 		$class = ' class="' . $class . '"';


### PR DESCRIPTION
Since there was not $image defined nor any $_zp_current_image, getSizeCustomImage(), if called from printCustomAlbumThumbImage(), always returned "false", leading to missing width and heigth for
album thumbs. 

Keep in mind that some changes are probably needed in themes too, because the variable $size passed to the function, at least by the zenpage theme, is "NULL" at the moment, as you can see here for zenpage/gallery.php:
https://github.com/zenphoto/zenphoto/blob/b24da2fd019194bbc63ac5c3584d95246e4d573a/themes/zenpage/gallery.php#L46
Same thing for album.php and search.php...
In my theme I've tested the value 95, but it also seems to work properly using either false or an empty string.

I'm not sure I'm proposing the best solution for this issue, or if I'm missing some contraindication, so please give it a closer look. Thanks,