### PR TITLE
secureServer function: consider https requests behind reverse proxies

### DIFF
--- a/zp-core/functions-basic.php
+++ b/zp-core/functions-basic.php
@@ -1536,6 +1536,10 @@ function secureServer() {
 		}
 	} elseif (isset($_SERVER['SERVER_PORT']) && ( '443' == $_SERVER['SERVER_PORT'] )) {
 		return true;
+	} elseif (isset($_SERVER['HTTP_FORWARDED']) && preg_match("/^(.+[,;])?\s*proto=https\s*([,;].*)$/", strtolower($_SERVER['HTTP_FORWARDED']))) {
+		return true;
+	} elseif (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && ('https' == strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']))) {
+		return true;
 	}
 	return false;
 }


### PR DESCRIPTION
When we setup zenphoto behind a reverse proxy such as nginx or haproxy, the server thinks it is receiving an http request while the client has submitted an https request....resulting in an infinite redirection loop.

In that case, the reverse proxy can add a "Forwarded" or "X-Forwarded-Proto" header to inform the backend about the real protocol used by the client. (see https://www.nginx.com/resources/wiki/start/topics/examples/forwarded/ )
