### PR TITLE
Fix empty link for newsOnIndex

### DIFF
--- a/themes/zenpage/functions.php
+++ b/themes/zenpage/functions.php
@@ -102,9 +102,9 @@ function newsOnIndex($link, $obj, $page) {
 	if (is_string($obj) && $obj == 'news.php') {
 		if (MOD_REWRITE) {
 			if (preg_match('~' . _NEWS_ . '[/\d/]*$~', $link)) {
-				$link = WEBPATH;
+				$link = WEBPATH . '/';
 				if ($page > 1)
-					$link .= '/' . _PAGE_ . '/' . $page;
+					$link .=  _PAGE_ . '/' . $page;
 			}
 		} else {
 			if (strpos($link, 'category=') === false && strpos($link, 'title=') === false) {


### PR DESCRIPTION
Working on a new theme using some zenpage theme's functions, I found a little bug that leads to an empty link to the first page of news if the option `zenpage_zp_index_news` is active.
It seems to me that the changes in this commit fix the problem, I'm not sure if there are some contraindications though. 

PS
I hope to be able to release and share my new theme as soon as possible.