### PR TITLE
Hide Comment Form RSS link if comments are disabled

### DIFF
--- a/zp-core/zp-extensions/comment_form.php
+++ b/zp-core/zp-extensions/comment_form.php
@@ -438,6 +438,27 @@ function printCommentForm($showcomments = true, $addcommenttext = NULL, $addhead
 				</div><!-- id="commententry" -->
 				<?php
 			}
+			if (getOption('comment_form_rss') && getOption('RSS_comments')) {
+				?>
+				<br class="clearall" />
+				<?php
+				if (class_exists('RSS')) {
+					switch ($_zp_gallery_page) {
+						case "image.php":
+							printRSSLink("Comments-image", "", gettext("Subscribe to comments"), "");
+							break;
+						case "album.php":
+							printRSSLink("Comments-album", "", gettext("Subscribe to comments"), "");
+							break;
+						case "news.php":
+							printRSSLink("Comments-news", "", gettext("Subscribe to comments"), "");
+							break;
+						case "pages.php":
+							printRSSLink("Comments-page", "", gettext("Subscribe to comments"), "");
+							break;
+					}
+				}
+			}
 		} else {
 			?>
 			<div id="commententry">
@@ -447,29 +468,6 @@ function printCommentForm($showcomments = true, $addcommenttext = NULL, $addhead
 		}
 		?>
 	</div><!-- id="commentcontent" -->
-	<?php
-	if (getOption('comment_form_rss') && getOption('RSS_comments')) {
-		?>
-		<br class="clearall" />
-		<?php
-		if (class_exists('RSS')) {
-			switch ($_zp_gallery_page) {
-				case "image.php":
-					printRSSLink("Comments-image", "", gettext("Subscribe to comments"), "");
-					break;
-				case "album.php":
-					printRSSLink("Comments-album", "", gettext("Subscribe to comments"), "");
-					break;
-				case "news.php":
-					printRSSLink("Comments-news", "", gettext("Subscribe to comments"), "");
-					break;
-				case "pages.php":
-					printRSSLink("Comments-page", "", gettext("Subscribe to comments"), "");
-					break;
-			}
-		}
-	}
-	?>
 	<!-- end printCommentForm -->
 	<?php
 }


### PR DESCRIPTION
Moved the code to print the RSS link of the comment form, to avoid displaying the link when comments are disabled, since in such a case there is nothing to follow on a particular item.