### PR TITLE
Three proposed small fixes for news category menu, news category feed and comments feed

### DIFF
--- a/zp-core/class-feed.php
+++ b/zp-core/class-feed.php
@@ -566,7 +566,7 @@ class feed {
 				$category = get_language_string($item['albumtitle']);
 				$website = $item['website'];
 				$title = $category . ": " . $title;
-				$commentpath = PROTOCOL . '://' . $this->host . $link . "#" . $item['id'];
+				$commentpath = PROTOCOL . '://' . $this->host . $link . "#zp_comment_id_" . $item['id'];
 				break;
 			case 'albums':
 				$obj = newAlbum($item['folder']);
@@ -574,7 +574,7 @@ class feed {
 				$feeditem['pubdate'] = date("r", strtotime($item['date']));
 				$title = get_language_string($item['albumtitle']);
 				$website = $item['website'];
-				$commentpath = PROTOCOL . '://' . $this->host . $link . "#" . $item['id'];
+				$commentpath = PROTOCOL . '://' . $this->host . $link . "#zp_comment_id_" . $item['id'];
 				break;
 			case 'news':
 			case 'pages':
@@ -590,7 +590,7 @@ class feed {
 					} else {
 						$obj = new ZenpagePage($titlelink);
 					}
-					$commentpath = PROTOCOL . '://' . $this->host . html_encode($obj->getLink()) . "#" . $item['id'];
+					$commentpath = PROTOCOL . '://' . $this->host . html_encode($obj->getLink()) . "#zp_comment_id_" . $item['id'];
 				} else {
 					$commentpath = '';
 				}

--- a/zp-core/zp-extensions/rss.php
+++ b/zp-core/zp-extensions/rss.php
@@ -509,7 +509,11 @@ class RSS extends feed {
 						}
 						break;
 				}
-				$this->channel_title = html_encode($this->channel_title . $this->cattitle . $titleappendix);
+				$cattitle = "";
+				if ($this->cattitle) {
+					$cattitle = " - " . $this->cattitle;
+				}
+				$this->channel_title = html_encode($this->channel_title . $cattitle . $titleappendix);
 				$this->itemnumber = getOption("RSS_zenpage_items"); // # of Items displayed on the feed
 				require_once(SERVERPATH . '/' . ZENFOLDER . '/' . PLUGIN_FOLDER . '/image_album_statistics.php');
 				require_once(SERVERPATH . '/' . ZENFOLDER . '/' . PLUGIN_FOLDER . '/zenpage/zenpage-template-functions.php');

--- a/zp-core/zp-extensions/zenpage/zenpage-template-functions.php
+++ b/zp-core/zp-extensions/zenpage/zenpage-template-functions.php
@@ -715,21 +715,21 @@ function printCurrentNewsArchive($before = '', $mode = 'formatted', $format = '%
  * @param string $newsindex How you want to call the link the main news page without a category, leave empty if you don't want to print it at all.
  * @param bool $counter TRUE or FALSE (default TRUE). If you want to show the number of articles behind the category name within brackets,
  * @param string $css_id The CSS id for the list
- * @param string $css_class_active The css class for the active menu item
+ * @param string $css_class_topactive The css class for the active menu item
  * @param bool $startlist set to true to output the UL tab
- * @param int $showsubs Set to depth of sublevels that should be shown always. 0 by default. To show all, set to a true! Only valid if option=="list".
  * @param string $css_class CSS class of the sub level list(s)
- * @param string $$css_class_active CSS class of the sub level list(s)
+ * @param string $css_class_active CSS class of the sub level list(s)
  * @param string $option The mode for the menu:
  * 												"list" context sensitive toplevel plus sublevel pages,
  * 												"list-top" only top level pages,
  * 												"omit-top" only sub level pages
  * 												"list-sub" lists only the current pages direct offspring
+ * @param int $showsubs Set to depth of sublevels that should be shown always. 0 by default. To show all, set to a true! Only valid if option=="list".
  * @param int $limit truncation of display text
  * @return string
  */
 function printAllNewsCategories($newsindex = 'All news', $counter = TRUE, $css_id = '', $css_class_topactive = '', $startlist = true, $css_class = '', $css_class_active = '', $option = 'list', $showsubs = false, $limit = NULL) {
-	printNestedMenu($option, 'allcategories', $counter, $css_id, $css_class_topactive, $css_class, $css_class_active, $newsindex, $showsubs, $startlist, $limit);
+	printNestedMenu($option, 'categories', $counter, $css_id, $css_class_topactive, $css_class, $css_class_active, $newsindex, $showsubs, $startlist, $limit);
 }
 
 /* * ********************************************* */


### PR DESCRIPTION
1. printAllNewsCategories is not showing subcategories in list mode, which should be the expected context sensitive behavior.
While it's possible to bypass this function, using directly printNestedMenu with the proper parameters (I'm going to do so in my themes from now on), it's probably also possible to easily fix this, if there are not unwanted consequences somewhere else that I'm not aware of.
2. Having played a bit with RSS feeds in the past few days, I noticed the possibility to create a feed for latest news from a single category. Probably nobody is using it anymore, but the title of that feed is missing a separator between gallery title and category title. Hopefully this trivial fix can solve the problem, unless there is a better way.
3. Links from comments feed to a real comment are pointing to the right page, but not to the right comment because of an incomplete id name.