### PR TITLE
Allow caching images assigned to a dynamic album from its admin-edit page

### DIFF
--- a/zp-core/admin-functions.php
+++ b/zp-core/admin-functions.php
@@ -1989,12 +1989,14 @@ function printAdminHeader($tab, $subtab = NULL) {
 	 */
 	function printAlbumButtons($album) {
 		if ($imagcount = $album->getNumImages() > 0) {
+			if (!$album->isDynamic()) {
 			?>
-			<div class="button buttons tooltip" title="<?php echo addslashes(gettext("Clears the album’s cached images.")); ?>">
-				<a href="<?php echo WEBPATH . '/' . ZENFOLDER . '/admin-edit.php?action=clear_cache&amp;album=' . html_encode($album->name); ?>&amp;XSRFToken=<?php echo getXSRFToken('clear_cache'); ?>">
-					<img src="images/edit-delete.png" /><?php echo gettext('Clear album image cache'); ?></a>
-				<br class="clearall" />
-			</div>
+				<div class="button buttons tooltip" title="<?php echo addslashes(gettext("Clears the album’s cached images.")); ?>">
+					<a href="<?php echo WEBPATH . '/' . ZENFOLDER . '/admin-edit.php?action=clear_cache&amp;album=' . html_encode($album->name); ?>&amp;XSRFToken=<?php echo getXSRFToken('clear_cache'); ?>">
+						<img src="images/edit-delete.png" /><?php echo gettext('Clear album image cache'); ?></a>
+					<br class="clearall" />
+				</div>
+			<?php } ?>
 			<div class="button buttons tooltip" title="<?php echo gettext("Resets album’s hit counters."); ?>">
 				<a href="<?php echo WEBPATH . '/' . ZENFOLDER . '/admin-edit.php?action=reset_hitcounters&amp;album=' . html_encode($album->name) . '&amp;albumid=' . $album->getID(); ?>&amp;XSRFToken=<?php echo getXSRFToken('hitcounter'); ?>">
 					<img src="images/reset.png" /><?php echo gettext('Reset album hit counters'); ?></a>

--- a/zp-core/zp-extensions/cacheManager.php
+++ b/zp-core/zp-extensions/cacheManager.php
@@ -679,7 +679,12 @@ class cacheManager {
 							}
 							$args = array($size, $width, $height, $cw, $ch, $cx, $cy, NULL, $thumbstandin, NULL, $thumbstandin, $passedWM, NULL, $effects);
 							$args = getImageParameters($args, $albumobj->name);
-							$uri = getImageURI($args, $albumobj->name, $imageobj->filename, $imageobj->filemtime);
+							if ($albumobj->isDynamic()) {
+								$folder = $imageobj->album->name;
+							} else {
+								$folder = $albumobj->name;
+							}
+							$uri = getImageURI($args, $folder, $imageobj->filename, $imageobj->filemtime);
 							if (strpos($uri, 'i.php?') !== false) {
 								$sizes_count++;
 								$sizeuris[] = $uri;

--- a/zp-core/zp-extensions/cacheManager/cacheImages.php
+++ b/zp-core/zp-extensions/cacheManager/cacheImages.php
@@ -282,7 +282,7 @@ printAdminHeader('overview', 'images'); ?>
 				@set_time_limit(3000);
 				foreach ($allalbums as $album) {
 					$albumobj = newAlbum($album);
-					if (!$albumobj->isDynamic()) {
+					if (!$albumobj->isDynamic() || count($allalbums) == 1) {
 						cacheManager::loadAlbums($albumobj);
 					}
 				} 


### PR DESCRIPTION
And remove the button for cache cleaning from the same page