### PR TITLE
Fix return type in phpdoc 

### DIFF
--- a/zp-core/zp-extensions/image_album_statistics.php
+++ b/zp-core/zp-extensions/image_album_statistics.php
@@ -332,7 +332,7 @@ function printAlbumStatisticItem($album, $option, $showtitle = false, $showdate 
  * @param string $albumfolder foldername of an specific album
  * @param bool $collection only if $albumfolder is set: true if you want to get statistics from this album and all of its subalbums
  * @param integer $threshold the minimum number of ratings (for rating options) or hits (for popular option) an image must have to be included in the list. (Default 0)
- * @return string
+ * @return array
  */
 function getImageStatistic($number, $option, $albumfolder = '', $collection = false, $threshold = 0, $sortdirection = 'desc') {
   global $_zp_gallery;


### PR DESCRIPTION
Fix a return type in phpdoc.  
The function `getImageStatistic()` should be returning `array` type.