### PR TITLE
Improve performance with many admins

### DIFF
--- a/zp-core/class-authority.php
+++ b/zp-core/class-authority.php
@@ -834,10 +834,10 @@ class Authority {
 		}
 		if (!$star) {
 			$admins = $this->getAdministrators();
-			while (count($admins) > 0) {
-				$user = array_shift($admins);
+			foreach($admins as $user) {
 				if ($user['email']) {
 					$star = $showCaptcha;
+					break;
 				}
 			}
 		}


### PR DESCRIPTION
array_shift is a very expensive operation since it reindexes the array on each loop

This change brought down my average CPU use by 20% with thousands of admins