### PR TITLE
Fix unique_option constraint being removed

### DIFF
--- a/zp-core/setup/index.php
+++ b/zp-core/setup/index.php
@@ -2449,9 +2449,6 @@ if ($c <= 0) {
 						$sql_statements[] = "ALTER TABLE $tbl_administrators ADD COLUMN `lastvisit` datetime default NULL";
 						$sql_statements[] = "ALTER TABLE $tbl_pages CHANGE `sort_order` `sort_order` varchar(48) DEFAULT NULL";
 
-						// this statement will fail on MySQL 5.7.4
-						$sql_statements[] = "ALTER IGNORE TABLE $tbl_options ADD UNIQUE `unique_option` (`name`, `ownerid`, `theme`)";
-
 						// do this last incase there are any field changes of like names!
 						foreach ($_zp_exifvars as $key => $exifvar) {
 							if ($s = $exifvar[6]) {

--- a/zp-core/setup/index.php
+++ b/zp-core/setup/index.php
@@ -2330,8 +2330,7 @@ if ($c <= 0) {
 						$sql_statements[] = "ALTER TABLE $tbl_albums CHANGE `album_theme` `album_theme` varchar(127) DEFAULT NULL";
 						$sql_statements[] = "ALTER TABLE $tbl_options ADD COLUMN `theme` varchar(127) NOT NULL";
 						$sql_statements[] = "ALTER TABLE $tbl_options CHANGE `name` `name` varchar(191) DEFAULT NULL";
-						$sql_statements[] = "ALTER TABLE $tbl_options DROP INDEX `unique_option`";
-						$sql_statements[] = "ALTER TABLE $tbl_options ADD UNIQUE `unique_option` (`name`, `ownerid`, `theme`)";
+						$sql_statements[] = "ALTER TABLE $tbl_options DROP INDEX `unique_option`; ALTER TABLE $tbl_options ADD UNIQUE `unique_option` (`name`, `ownerid`, `theme`)";
 						$sql_statements[] = 'ALTER TABLE ' . $tbl_images . ' DROP COLUMN `EXIFValid`';
 						$sql_statements[] = 'ALTER TABLE ' . $tbl_images . ' ADD COLUMN `hasMetadata` int(1) default 0';
 						$sql_statements[] = 'UPDATE ' . $tbl_images . ' SET `date`=NULL WHERE `date`="0000-00-00 00:00:00"'; // empty dates should be NULL
@@ -2449,6 +2448,9 @@ if ($c <= 0) {
 						//1.5.8
 						$sql_statements[] = "ALTER TABLE $tbl_administrators ADD COLUMN `lastvisit` datetime default NULL";
 						$sql_statements[] = "ALTER TABLE $tbl_pages CHANGE `sort_order` `sort_order` varchar(48) DEFAULT NULL";
+
+						// this statement will fail on MySQL 5.7.4
+						$sql_statements[] = "ALTER IGNORE TABLE $tbl_options ADD UNIQUE `unique_option` (`name`, `ownerid`, `theme`)";
 
 						// do this last incase there are any field changes of like names!
 						foreach ($_zp_exifvars as $key => $exifvar) {


### PR DESCRIPTION
This is a problem that continues to happen to me and others sometimes. There are other mentions of it on here and the zenphoto forum, including from me in 2014 (and it happened to me twice this year)
e.g.
https://forum.zenphoto.org/discussion/906506/options-table-spam
https://forum.zenphoto.org/discussion/1410812/millions-of-records-in-the-options-table-duplicate-options-continuously-created
https://github.com/zenphoto/zenphoto/issues/532

I finally looked into the code and I believe I have found the cause of it - if the database update script is run while users are still browsing the website, there could be a race-condition:

1) Drop the constraint (line 2333)
2) A duplicate entry is added to the table
3) Try to add the constraint (line 2334) but it fails because of the duplicate

Here, the existing drop and alter command are run as one query instead of two, which should reduce or eliminate the chance that another db operation happens in between them. Some databases may even guarantee the safety of this operation with their internal locks, but I don't know if that can be relied upon with all SQL implementations.

A more bulletproof fix would likely require locking zenphoto while these scripts run, but I think this will be an improvement if not a fix for some users. It does fix it for me.