### PR TITLE
Related items for tags with blank chars

### DIFF
--- a/zp-core/zp-extensions/related_items.php
+++ b/zp-core/zp-extensions/related_items.php
@@ -18,6 +18,9 @@ function getRelatedItems($type = 'news', $album = NULL) {
 		$searchstring = '';
 		$count = '';
 		foreach ($tags as $tag) {
+			if (strpos($tag, " ") !== false) {
+				$tag = '"' . $tag . '"';
+			}
 			$count++;
 			if ($count == 1) {
 				$bool = '';


### PR DESCRIPTION
If an element has a multiple words tag, getRelatedItems('all') returns an empty array. Since multiple words tags are allowed by zenphoto, returning proper search results, I guess they should work also for related items searches. This is a possible fix, tested and working, but could there be a better solution?