### PR TITLE
Fix missing custom copyright site url

### DIFF
--- a/zp-core/class-gallery.php
+++ b/zp-core/class-gallery.php
@@ -155,7 +155,7 @@ class Gallery {
 		$url = $this->get('copyright_site_url');
 		if ($url) {
 			if ($url == 'custom') {
-				return getOption('copyright_site_url_custom');
+				return $this->get('copyright_site_url_custom');
 			} else if ($url == 'none') {
 				return null;
 			} else {


### PR DESCRIPTION
getOption() there doesn't work because it is stored in the gallery object option. 