### PR TITLE
Proper password page for downloadList

### DIFF
--- a/zp-core/template-functions.php
+++ b/zp-core/template-functions.php
@@ -4063,6 +4063,9 @@ function checkForGuest(&$hint = NULL, &$show = NULL) {
 function checkAccess(&$hint = NULL, &$show = NULL) {
 	global $_zp_current_album, $_zp_current_search, $_zp_gallery, $_zp_gallery_page,
 	$_zp_current_zenpage_page, $_zp_current_zenpage_news;
+	if (isset($_GET['download']) && extensionEnabled('downloadList')) {
+		return false; // Handled by downloadList extension
+	}
 	if (GALLERY_SECURITY != 'public') // only registered users allowed
 		$show = true; //	therefore they will need to supply their user id is something fails below
 

--- a/zp-core/zp-extensions/downloadList.php
+++ b/zp-core/zp-extensions/downloadList.php
@@ -474,6 +474,7 @@ class AlbumZip {
 			self::AddAlbum($album, strlen($albumname), $album->localpath);
 		}
 		if(!empty($_zp_zip_list)) {
+			DownloadList::updateListItemCount($albumname . '.zip');
 			$zip = new ZipStream($albumname . '.zip', $opt);
 			zp_setCookie('zpcms_albumzip_ready', 1, 1, null, secureServer());
 			foreach ($_zp_zip_list as $path => $file) {
@@ -703,7 +704,6 @@ if (isset($_GET['download'])) {
 		return;
 	}
 	if (isset($_GET['albumzip'])) {
-		DownloadList::updateListItemCount($item . '.zip');
 		require_once(SERVERPATH . '/' . ZENFOLDER . '/lib-zipStream.php');
 		if (isset($_GET['fromcache'])) {
 			$fromcache = sanitize(isset($_GET['fromcache']));

--- a/zp-core/zp-extensions/downloadList.php
+++ b/zp-core/zp-extensions/downloadList.php
@@ -480,8 +480,8 @@ class AlbumZip {
 				@set_time_limit(6000);
 				$zip->add_file_from_path(internalToFilesystem($file), internalToFilesystem($path));
 			}
-			$zip->finish(); 
-			return true;
+			$zip->finish();
+			exitZP();
 		}
 		return false;
 	}

--- a/zp-core/zp-extensions/downloadList.php
+++ b/zp-core/zp-extensions/downloadList.php
@@ -775,3 +775,6 @@ if (isset($_GET['download'])) {
 		}
 	}
 }
+// TODO:
+// 1) Include dynamic albums as well
+// 2) Handle properly album_name.zip files in download statistic, as for now they result missing even if the album is present. Statistics for album download get erased by pressing the "Clear outdated downloads from database".


### PR DESCRIPTION
- Fix broken printDownloadURL for full image
- Fix check for album existence
- Added a new 404 message for broken downloads
- Set a very fast expiring cookie after list generation for album.zip
- Todo eventually: merge the old (and still used) internal 404/403 message with the new one