### PR TITLE
Fix typo and return date in getSearchDateFormatted

### DIFF
--- a/zp-core/classes/class-searchengine.php
+++ b/zp-core/classes/class-searchengine.php
@@ -2059,9 +2059,8 @@ class SearchEngine {
 		}
 		if ($date == '0000-00') {
 			return gettext("no date");
-		};
-		$dt = strtotime($date . "-01");
-		return zpFormattedDate($format, $dt);
+		}
+		return getFormattedLocaleDate($format, $dt);
 	}
 	
 	/**


### PR DESCRIPTION
Found that the return date coming from `getSearchDateFormatted` was wrong, not always but sometimes. It's been fixed now.