### PR TITLE
Fix for number of pages returned by getPages()

### DIFF
--- a/zp-core/zp-extensions/zenpage/class-zenpage.php
+++ b/zp-core/zp-extensions/zenpage/class-zenpage.php
@@ -202,10 +202,10 @@ class Zenpage {
 					$page = new ZenpagePage($row['titlelink']);
 					if ($page->isMyItem(LIST_RIGHTS)) {
 						$all_pages[] = $row;
-						if ($number && count($result) >= $number) {
-							break;
-						}
 					}
+				}
+				if ($number && count($all_pages) >= $number) {
+					break;
 				}
 			}
 			$_zp_db->freeResult($result);


### PR DESCRIPTION
This method was ignoring the $number parameter and returning always all of the pages.