### PR TITLE
openstreetmap: markers styling and replacement of thumbs

### DIFF
--- a/zp-core/zp-extensions/openstreetmap.php
+++ b/zp-core/zp-extensions/openstreetmap.php
@@ -569,7 +569,7 @@ class openStreetMap {
 		$result = array();
 		$gps = $image->getGeodata();
 		if ($gps) {
-			$thumb = "<a href='" . $image->getLink() . "' title='" . $image->getTitle() . "'><img src='" . $image->getThumb() . "' alt='" . $image->getTitle() . "' class='openstreetmap-thumbs' /></a>";
+			$thumb = "<a href='" . $image->getLink() . "' title='" . $image->getTitle() . "'><img src='" . $image->getThumb() . "' alt='" . $image->getTitle() . "' class='openstreetmap-thumb' /></a>";
 			$current = 0;
 			if ($this->mode == 'single-cluster' && isset($_zp_current_image) && ($image->filename == $_zp_current_image->filename && $image->getAlbumname() == $_zp_current_image->getAlbumname())) {
 				$current = 1;

--- a/zp-core/zp-extensions/openstreetmap.php
+++ b/zp-core/zp-extensions/openstreetmap.php
@@ -569,7 +569,7 @@ class openStreetMap {
 		$result = array();
 		$gps = $image->getGeodata();
 		if ($gps) {
-			$thumb = "<a href='" . $image->getLink() . "'><img src='" . $image->getCustomImage(150, NULL, NULL, NULL, NULL, NULL, NULL, true) . "' alt='" . $image->getTitle() . "' /></a>";
+			$thumb = "<a href='" . $image->getLink() . "'><img src='" . $image->getCustomImage(150, NULL, NULL, NULL, NULL, NULL, NULL, true) . "' alt='" . $image->getTitle() . "' class='openstreetmap-thumbs' /></a>";
 			$current = 0;
 			if ($this->mode == 'single-cluster' && isset($_zp_current_image) && ($image->filename == $_zp_current_image->filename && $image->getAlbumname() == $_zp_current_image->getAlbumname())) {
 				$current = 1;

--- a/zp-core/zp-extensions/openstreetmap.php
+++ b/zp-core/zp-extensions/openstreetmap.php
@@ -569,7 +569,7 @@ class openStreetMap {
 		$result = array();
 		$gps = $image->getGeodata();
 		if ($gps) {
-			$thumb = "<a href='" . $image->getLink() . "'><img src='" . $image->getCustomImage(150, NULL, NULL, NULL, NULL, NULL, NULL, true) . "' alt='" . $image->getTitle() . "' class='openstreetmap-thumbs' /></a>";
+			$thumb = "<a href='" . $image->getLink() . "'><img src='" . $image->getThumb() . "' alt='" . $image->getTitle() . "' class='openstreetmap-thumbs' /></a>";
 			$current = 0;
 			if ($this->mode == 'single-cluster' && isset($_zp_current_image) && ($image->filename == $_zp_current_image->filename && $image->getAlbumname() == $_zp_current_image->getAlbumname())) {
 				$current = 1;

--- a/zp-core/zp-extensions/openstreetmap.php
+++ b/zp-core/zp-extensions/openstreetmap.php
@@ -569,7 +569,7 @@ class openStreetMap {
 		$result = array();
 		$gps = $image->getGeodata();
 		if ($gps) {
-			$thumb = "<a href='" . $image->getLink() . "'><img src='" . $image->getCustomImage(150, NULL, NULL, NULL, NULL, NULL, NULL, true) . "' alt='' /></a>";
+			$thumb = "<a href='" . $image->getLink() . "'><img src='" . $image->getCustomImage(150, NULL, NULL, NULL, NULL, NULL, NULL, true) . "' alt='" . $image->getTitle() . "' /></a>";
 			$current = 0;
 			if ($this->mode == 'single-cluster' && isset($_zp_current_image) && ($image->filename == $_zp_current_image->filename && $image->getAlbumname() == $_zp_current_image->getAlbumname())) {
 				$current = 1;

--- a/zp-core/zp-extensions/openstreetmap.php
+++ b/zp-core/zp-extensions/openstreetmap.php
@@ -569,7 +569,7 @@ class openStreetMap {
 		$result = array();
 		$gps = $image->getGeodata();
 		if ($gps) {
-			$thumb = "<a href='" . $image->getLink() . "'><img src='" . $image->getThumb() . "' alt='" . $image->getTitle() . "' class='openstreetmap-thumbs' /></a>";
+			$thumb = "<a href='" . $image->getLink() . "' title='" . $image->getTitle() . "'><img src='" . $image->getThumb() . "' alt='" . $image->getTitle() . "' class='openstreetmap-thumbs' /></a>";
 			$current = 0;
 			if ($this->mode == 'single-cluster' && isset($_zp_current_image) && ($image->filename == $_zp_current_image->filename && $image->getAlbumname() == $_zp_current_image->getAlbumname())) {
 				$current = 1;

--- a/zp-core/zp-extensions/openstreetmap.php
+++ b/zp-core/zp-extensions/openstreetmap.php
@@ -577,7 +577,7 @@ class openStreetMap {
 			$result = array(
 					'lat' => $gps['lat'],
 					'long' => $gps['long'],
-					'title' => "<a href='" . $image->getLink() . "' class='openstreetmap-title'>". js_encode(shortenContent($image->getTitle(), 50, '...')) . "</a>",
+					'title' => "<a href='" . $image->getLink() . "' title='" . $image->getTitle() . "' class='openstreetmap-title'>". js_encode(shortenContent($image->getTitle(), 50, '...')) . "</a>",
 					'desc' => js_encode(shortenContent($image->getDesc(), 100, '...')),
 					'thumb' => $thumb,
 					'current' => $current

--- a/zp-core/zp-extensions/openstreetmap.php
+++ b/zp-core/zp-extensions/openstreetmap.php
@@ -577,7 +577,7 @@ class openStreetMap {
 			$result = array(
 					'lat' => $gps['lat'],
 					'long' => $gps['long'],
-					'title' => "<a href='" . $image->getLink() . "'>". js_encode(shortenContent($image->getTitle(), 50, '...')) . "</a><br />",
+					'title' => "<a href='" . $image->getLink() . "' class='openstreetmap-title'>". js_encode(shortenContent($image->getTitle(), 50, '...')) . "</a>",
 					'desc' => js_encode(shortenContent($image->getDesc(), 100, '...')),
 					'thumb' => $thumb,
 					'current' => $current


### PR DESCRIPTION
- Added missing `title` attributes to Image page links for markers on the map (title & thumb)
- Added classes for styling of title and thumbs for markers on the map (`openstreetmap-thumb`, `openstreetmap-title`)
- Added missing `alt` attribute to thumbs for markers on the map
- Removed trailing `<br>` after titles in thumbs (unnecessary, if need be - styling can be done with CSS now)
- Replaced `getCustomImage` with `getThumb` for markers on the map - this speeds up loading, as they are already cached + cleans up search engines results (see report from Google Search console below) 

`getCustomImage` generates additional images, which are blocked by robots.txt file and overfill console with results of little value

![image](https://github.com/zenphoto/zenphoto/assets/75898540/6fe2a9c5-3e01-4f0b-8b9f-71791fd89581)
