### PR TITLE
openstreetmap: markers styling and new options

### DIFF
--- a/zp-core/zp-extensions/openstreetmap.php
+++ b/zp-core/zp-extensions/openstreetmap.php
@@ -44,7 +44,7 @@ class openStreetMapOptions {
 		setOptionDefault('osmap_markerpopup_desc', 1);
 		setOptionDefault('osmap_markerpopup_thumb', 1);
 		setOptionDefault('osmap_markerpopup_thumb-type', 'custom');
-		setOptionDefault('osmap_markerpopup_thumb-size', 120);
+		setOptionDefault('osmap_markerpopup_thumb-size', 150);
 		setOptionDefault('osmap_markerpopup_title-length', 50);
 		setOptionDefault('osmap_markerpopup_desc-length', 100);
 		setOptionDefault('osmap_markerpopup_css-default', 1);
@@ -63,7 +63,7 @@ class openStreetMapOptions {
 		setOptionDefault('osmap_cluster_showcoverage_on_hover', 0);
 		if (class_exists('cacheManager')) {
 			cacheManager::deleteCacheSizes('openstreetmap');
-			cacheManager::addCacheSize('openstreetmap', 120, NULL, NULL, NULL, NULL, NULL, NULL, true, NULL, NULL, NULL);
+			cacheManager::addCacheSize('openstreetmap', 150, NULL, NULL, NULL, NULL, NULL, NULL, true, NULL, NULL, NULL);
 		}
 	}
 
@@ -157,7 +157,7 @@ class openStreetMapOptions {
 						'key' => 'osmap_markerpopup_thumb-size',
 						'type' => OPTION_TYPE_TEXTBOX,
 						'order' => 14.2,
-						'desc' => gettext("Set the width of the Custom Image to be used as thumb in the marker popups. Works if Custom image is selected in the previous option. Default size is 120px.<br>If Custom Image size is larger than 120px, you might need to use custom CSS to display them in full (see option below to disable default CSS file).")),
+						'desc' => gettext("Set the width of the Custom Image to be used as thumb in the marker popups. Works if Custom image is selected in the previous option. Default size is 150px.<br>If Custom Image size is larger than 120px, the image will be shrinked to 120px, if you want to display them in full - you might need to use custom CSS (see option below to disable default CSS file).")),
 				gettext('Length of Image title') => array(
 						'key' => 'osmap_markerpopup_title-length',
 						'type' => OPTION_TYPE_TEXTBOX,
@@ -172,7 +172,7 @@ class openStreetMapOptions {
 						'key' => 'osmap_markerpopup_css-default',
 						'type' => OPTION_TYPE_CHECKBOX,
 						'order' => 14.5,
-						'desc' => gettext("Check to use default openstreetmap CSS (located in 'PLUGIN_FOLDER/openstreetmap/openstreetmap.css'). Default is Enabled.<br>Removing checkmark will DISABLE default plugin CSS - this will allow to change popup markers presentation completely, make sure to include relevant rules in your theme CSS file.")),
+						'desc' => gettext("Check to use default openstreetmap CSS (located in 'PLUGIN_FOLDER/openstreetmap/openstreetmap.css'). Default is Enabled.<br>Removing checkmark will DISABLE default plugin CSS - this option is intended for experienced users, who want to have full control and will allow to change map and popup markers presentation completely, so make sure to include relevant rules in your theme CSS file.")),
 				gettext('Show layers controls') => array(
 						'key' => 'osmap_showlayerscontrol',
 						'type' => OPTION_TYPE_CHECKBOX,

--- a/zp-core/zp-extensions/openstreetmap.php
+++ b/zp-core/zp-extensions/openstreetmap.php
@@ -569,7 +569,7 @@ class openStreetMap {
 		$result = array();
 		$gps = $image->getGeodata();
 		if ($gps) {
-			$thumb = "<a href='" . $image->getLink() . "' title='" . $image->getTitle() . "'><img src='" . $image->getThumb() . "' alt='" . $image->getTitle() . "' class='openstreetmap-thumbs' /></a>";
+			$thumb = "<a href='" . $image->getLink() . "' title='" . $image->getTitle() . "'><img src='" . $image->getThumb() . "' alt='" . $image->getTitle() . "' class='openstreetmap-thumb' /></a>";
 			$current = 0;
 			if ($this->mode == 'single-cluster' && isset($_zp_current_image) && ($image->filename == $_zp_current_image->filename && $image->getAlbumname() == $_zp_current_image->getAlbumname())) {
 				$current = 1;

--- a/zp-core/zp-extensions/openstreetmap.php
+++ b/zp-core/zp-extensions/openstreetmap.php
@@ -152,12 +152,12 @@ class openStreetMapOptions {
 						'buttons' => array(
 								gettext('Default thumb size') => 'default',
 								gettext('Custom image') => 'custom'),
-						'desc' => gettext('Choose the size of the thumb to be displayed in the marker popups. Default thumb size is determined by the theme (See Options->Theme->Standard options: Thumb size). Custom image size can be set below.')),
+						'desc' => gettext('Choose the size of the thumb to be displayed in the marker popups. Default thumb size is determined by the theme (See Options->Theme->Standard options: Thumb size). Custom image size can be set below.<br>If Default thumb size is larger than 120px, you might need to use custom CSS to display them in full (see option below to disable default CSS file).')),
 				gettext('Custom image thumb size') => array(
 						'key' => 'osmap_markerpopup_thumb-size',
 						'type' => OPTION_TYPE_TEXTBOX,
 						'order' => 14.2,
-						'desc' => gettext("Set the width of the Custom Image to be used as thumb in the marker popups. Works if Custom image is selected in the previous option. Default size is 120px.")),
+						'desc' => gettext("Set the width of the Custom Image to be used as thumb in the marker popups. Works if Custom image is selected in the previous option. Default size is 120px.<br>If Custom Image size is larger than 120px, you might need to use custom CSS to display them in full (see option below to disable default CSS file).")),
 				gettext('Length of Image title') => array(
 						'key' => 'osmap_markerpopup_title-length',
 						'type' => OPTION_TYPE_TEXTBOX,

--- a/zp-core/zp-extensions/openstreetmap.php
+++ b/zp-core/zp-extensions/openstreetmap.php
@@ -569,7 +569,7 @@ class openStreetMap {
 		$result = array();
 		$gps = $image->getGeodata();
 		if ($gps) {
-			$thumb = "<a href='" . $image->getLink() . "'><img src='" . $image->getCustomImage(150, NULL, NULL, NULL, NULL, NULL, NULL, true) . "' alt='" . $image->getTitle() . "' /></a>";
+			$thumb = "<a href='" . $image->getLink() . "'><img src='" . $image->getCustomImage(150, NULL, NULL, NULL, NULL, NULL, NULL, true) . "' alt='" . $image->getTitle() . "' class='openstreetmap-thumbs' /></a>";
 			$current = 0;
 			if ($this->mode == 'single-cluster' && isset($_zp_current_image) && ($image->filename == $_zp_current_image->filename && $image->getAlbumname() == $_zp_current_image->getAlbumname())) {
 				$current = 1;

--- a/zp-core/zp-extensions/openstreetmap.php
+++ b/zp-core/zp-extensions/openstreetmap.php
@@ -158,12 +158,12 @@ class openStreetMapOptions {
 						'type' => OPTION_TYPE_TEXTBOX,
 						'order' => 14.2,
 						'desc' => gettext("Set the width of the Custom Image to be used as thumb in the marker popups. Works if Custom image is selected in the previous option. Default size is 120px.")),
-				gettext('Lenth of Image title') => array(
+				gettext('Length of Image title') => array(
 						'key' => 'osmap_markerpopup_title-length',
 						'type' => OPTION_TYPE_TEXTBOX,
 						'order' => 14.3,
 						'desc' => gettext("Set the length of the Image title to show in the marker popups. Leave EMPTY to display in full. Default is 50 characters.")),
-				gettext('Lenth of Image description') => array(
+				gettext('Length of Image description') => array(
 						'key' => 'osmap_markerpopup_desc-length',
 						'type' => OPTION_TYPE_TEXTBOX,
 						'order' => 14.4,

--- a/zp-core/zp-extensions/openstreetmap.php
+++ b/zp-core/zp-extensions/openstreetmap.php
@@ -569,7 +569,7 @@ class openStreetMap {
 		$result = array();
 		$gps = $image->getGeodata();
 		if ($gps) {
-			$thumb = "<a href='" . $image->getLink() . "'><img src='" . $image->getCustomImage(150, NULL, NULL, NULL, NULL, NULL, NULL, true) . "' alt='" . $image->getTitle() . "' class='openstreetmap-thumbs' /></a>";
+			$thumb = "<a href='" . $image->getLink() . "'><img src='" . $image->getThumb() . "' alt='" . $image->getTitle() . "' class='openstreetmap-thumbs' /></a>";
 			$current = 0;
 			if ($this->mode == 'single-cluster' && isset($_zp_current_image) && ($image->filename == $_zp_current_image->filename && $image->getAlbumname() == $_zp_current_image->getAlbumname())) {
 				$current = 1;

--- a/zp-core/zp-extensions/openstreetmap.php
+++ b/zp-core/zp-extensions/openstreetmap.php
@@ -152,12 +152,12 @@ class openStreetMapOptions {
 						'buttons' => array(
 								gettext('Default thumb size') => 'default',
 								gettext('Custom image') => 'custom'),
-						'desc' => gettext('Choose the size of the thumb to be displayed in the marker popups. Default thumb size is determined by the theme (See Options->Theme->Standard options: Thumb size). Custom image size can be set below.<br>If Default thumb size is larger than 120px, you might need to use custom CSS to display them in full (see option below to disable default CSS file).')),
+						'desc' => gettext('Choose the size of the thumb to be displayed in the marker popups. Default thumb size is determined by the theme (See Options->Theme->Standard options: Thumb size). Custom image size can be set below.<br>If Default thumb size is larger than 120px, you might need to use custom CSS to display them in full (see option below to disable default CSS files).')),
 				gettext('Custom image thumb size') => array(
 						'key' => 'osmap_markerpopup_thumb-size',
 						'type' => OPTION_TYPE_TEXTBOX,
 						'order' => 14.2,
-						'desc' => gettext("Set the width of the Custom Image to be used as thumb in the marker popups. Works if Custom image is selected in the previous option. Default size is 120px.<br>If Custom Image size is larger than 120px, you might need to use custom CSS to display them in full (see option below to disable default CSS file).")),
+						'desc' => gettext("Set the width of the Custom Image to be used as thumb in the marker popups. Works if Custom image is selected in the previous option. Default size is 120px.<br>If Custom Image size is larger than 120px, you might need to use custom CSS to display them in full (see option below to disable default CSS files).")),
 				gettext('Length of Image title') => array(
 						'key' => 'osmap_markerpopup_title-length',
 						'type' => OPTION_TYPE_TEXTBOX,
@@ -172,7 +172,7 @@ class openStreetMapOptions {
 						'key' => 'osmap_markerpopup_css-default',
 						'type' => OPTION_TYPE_CHECKBOX,
 						'order' => 14.5,
-						'desc' => gettext("Check to use default openstreetmap CSS (located in 'PLUGIN_FOLDER/openstreetmap/openstreetmap.css'). Default is Enabled.<br>Removing checkmark will DISABLE default plugin CSS - this will allow to change popup markers presentation completely, make sure to include relevant rules in your theme CSS file.")),
+						'desc' => gettext("Check to use default openstreetmap CSS files (located in '/zp-core/zp-extensions/openstreetmap/'). Default is Enabled.<br>Removing checkmark will DISABLE default CSS rules for Openstreetmap plugin - this option is intended for experienced users, who want to have full control and will allow to change map and popup markers presentation completely, so make sure to include relevant rules from openstreetmap.css, leaflet.css, MarkerCluster.css, MarkerCluster.Default.css in your theme CSS file and add custom images and icons.")),
 				gettext('Show layers controls') => array(
 						'key' => 'osmap_showlayerscontrol',
 						'type' => OPTION_TYPE_CHECKBOX,

--- a/zp-core/zp-extensions/openstreetmap.php
+++ b/zp-core/zp-extensions/openstreetmap.php
@@ -44,7 +44,7 @@ class openStreetMapOptions {
 		setOptionDefault('osmap_markerpopup_desc', 1);
 		setOptionDefault('osmap_markerpopup_thumb', 1);
 		setOptionDefault('osmap_markerpopup_thumb-type', 'custom');
-		setOptionDefault('osmap_markerpopup_thumb-size', 150);
+		setOptionDefault('osmap_markerpopup_thumb-size', 120);
 		setOptionDefault('osmap_markerpopup_title-length', 50);
 		setOptionDefault('osmap_markerpopup_desc-length', 100);
 		setOptionDefault('osmap_markerpopup_css-default', 1);
@@ -63,7 +63,7 @@ class openStreetMapOptions {
 		setOptionDefault('osmap_cluster_showcoverage_on_hover', 0);
 		if (class_exists('cacheManager')) {
 			cacheManager::deleteCacheSizes('openstreetmap');
-			cacheManager::addCacheSize('openstreetmap', 150, NULL, NULL, NULL, NULL, NULL, NULL, true, NULL, NULL, NULL);
+			cacheManager::addCacheSize('openstreetmap', 120, NULL, NULL, NULL, NULL, NULL, NULL, true, NULL, NULL, NULL);
 		}
 	}
 
@@ -157,7 +157,7 @@ class openStreetMapOptions {
 						'key' => 'osmap_markerpopup_thumb-size',
 						'type' => OPTION_TYPE_TEXTBOX,
 						'order' => 14.2,
-						'desc' => gettext("Set the width of the Custom Image to be used as thumb in the marker popups. Works if Custom image is selected in the previous option. Default size is 150px.<br>If Custom Image size is larger than 120px, the image will be shrinked to 120px, if you want to display them in full - you might need to use custom CSS (see option below to disable default CSS file).")),
+						'desc' => gettext("Set the width of the Custom Image to be used as thumb in the marker popups. Works if Custom image is selected in the previous option. Default size is 120px.<br>If Custom Image size is larger than 120px, you might need to use custom CSS to display them in full (see option below to disable default CSS file).")),
 				gettext('Length of Image title') => array(
 						'key' => 'osmap_markerpopup_title-length',
 						'type' => OPTION_TYPE_TEXTBOX,
@@ -172,7 +172,7 @@ class openStreetMapOptions {
 						'key' => 'osmap_markerpopup_css-default',
 						'type' => OPTION_TYPE_CHECKBOX,
 						'order' => 14.5,
-						'desc' => gettext("Check to use default openstreetmap CSS (located in 'PLUGIN_FOLDER/openstreetmap/openstreetmap.css'). Default is Enabled.<br>Removing checkmark will DISABLE default plugin CSS - this option is intended for experienced users, who want to have full control and will allow to change map and popup markers presentation completely, so make sure to include relevant rules in your theme CSS file.")),
+						'desc' => gettext("Check to use default openstreetmap CSS (located in 'PLUGIN_FOLDER/openstreetmap/openstreetmap.css'). Default is Enabled.<br>Removing checkmark will DISABLE default plugin CSS - this will allow to change popup markers presentation completely, make sure to include relevant rules in your theme CSS file.")),
 				gettext('Show layers controls') => array(
 						'key' => 'osmap_showlayerscontrol',
 						'type' => OPTION_TYPE_CHECKBOX,

--- a/zp-core/zp-extensions/openstreetmap.php
+++ b/zp-core/zp-extensions/openstreetmap.php
@@ -569,7 +569,7 @@ class openStreetMap {
 		$result = array();
 		$gps = $image->getGeodata();
 		if ($gps) {
-			$thumb = "<a href='" . $image->getLink() . "'><img src='" . $image->getCustomImage(150, NULL, NULL, NULL, NULL, NULL, NULL, true) . "' alt='' /></a>";
+			$thumb = "<a href='" . $image->getLink() . "'><img src='" . $image->getCustomImage(150, NULL, NULL, NULL, NULL, NULL, NULL, true) . "' alt='" . $image->getTitle() . "' /></a>";
 			$current = 0;
 			if ($this->mode == 'single-cluster' && isset($_zp_current_image) && ($image->filename == $_zp_current_image->filename && $image->getAlbumname() == $_zp_current_image->getAlbumname())) {
 				$current = 1;

--- a/zp-core/zp-extensions/openstreetmap.php
+++ b/zp-core/zp-extensions/openstreetmap.php
@@ -569,7 +569,7 @@ class openStreetMap {
 		$result = array();
 		$gps = $image->getGeodata();
 		if ($gps) {
-			$thumb = "<a href='" . $image->getLink() . "'><img src='" . $image->getThumb() . "' alt='" . $image->getTitle() . "' class='openstreetmap-thumbs' /></a>";
+			$thumb = "<a href='" . $image->getLink() . "' title='" . $image->getTitle() . "'><img src='" . $image->getThumb() . "' alt='" . $image->getTitle() . "' class='openstreetmap-thumbs' /></a>";
 			$current = 0;
 			if ($this->mode == 'single-cluster' && isset($_zp_current_image) && ($image->filename == $_zp_current_image->filename && $image->getAlbumname() == $_zp_current_image->getAlbumname())) {
 				$current = 1;

--- a/zp-core/zp-extensions/openstreetmap.php
+++ b/zp-core/zp-extensions/openstreetmap.php
@@ -577,7 +577,7 @@ class openStreetMap {
 			$result = array(
 					'lat' => $gps['lat'],
 					'long' => $gps['long'],
-					'title' => "<a href='" . $image->getLink() . "' class='openstreetmap-title'>". js_encode(shortenContent($image->getTitle(), 50, '...')) . "</a>",
+					'title' => "<a href='" . $image->getLink() . "' title='" . $image->getTitle() . "' class='openstreetmap-title'>". js_encode(shortenContent($image->getTitle(), 50, '...')) . "</a>",
 					'desc' => js_encode(shortenContent($image->getDesc(), 100, '...')),
 					'thumb' => $thumb,
 					'current' => $current

--- a/zp-core/zp-extensions/openstreetmap.php
+++ b/zp-core/zp-extensions/openstreetmap.php
@@ -152,7 +152,7 @@ class openStreetMapOptions {
 						'buttons' => array(
 								gettext('Default thumb size') => 'default',
 								gettext('Custom image') => 'custom'),
-						'desc' => gettext('Choose the size of the thumb to be displayed in the marker popups. Default thumb size is determined by the theme (See Options->Theme->Standard options:Thumb size). Custom image size can be set below.')),
+						'desc' => gettext('Choose the size of the thumb to be displayed in the marker popups. Default thumb size is determined by the theme (See Options->Theme->Standard options: Thumb size). Custom image size can be set below.')),
 				gettext('Custom image thumb size') => array(
 						'key' => 'osmap_markerpopup_thumb-size',
 						'type' => OPTION_TYPE_TEXTBOX,

--- a/zp-core/zp-extensions/openstreetmap.php
+++ b/zp-core/zp-extensions/openstreetmap.php
@@ -577,7 +577,7 @@ class openStreetMap {
 			$result = array(
 					'lat' => $gps['lat'],
 					'long' => $gps['long'],
-					'title' => "<a href='" . $image->getLink() . "'>". js_encode(shortenContent($image->getTitle(), 50, '...')) . "</a><br />",
+					'title' => "<a href='" . $image->getLink() . "' class='openstreetmap-title'>". js_encode(shortenContent($image->getTitle(), 50, '...')) . "</a>",
 					'desc' => js_encode(shortenContent($image->getDesc(), 100, '...')),
 					'thumb' => $thumb,
 					'current' => $current

--- a/zp-core/zp-extensions/openstreetmap.php
+++ b/zp-core/zp-extensions/openstreetmap.php
@@ -559,12 +559,12 @@ class openStreetMap {
 	 */
 	static function scripts() {
 		?>
-		<link rel="stylesheet" type="text/css" href="<?php echo FULLWEBPATH . '/' . ZENFOLDER . '/' . PLUGIN_FOLDER; ?>/openstreetmap/leaflet.css" />
-		<link rel="stylesheet" type="text/css" href="<?php echo FULLWEBPATH . '/' . ZENFOLDER . '/' . PLUGIN_FOLDER; ?>/openstreetmap/MarkerCluster.css" />
-		<link rel="stylesheet" type="text/css" href="<?php echo FULLWEBPATH . '/' . ZENFOLDER . '/' . PLUGIN_FOLDER; ?>/openstreetmap/MarkerCluster.Default.css" />
 		<?php
 		if (getOption('osmap_markerpopup_css-default')) {
 			?>
+			<link rel="stylesheet" type="text/css" href="<?php echo FULLWEBPATH . '/' . ZENFOLDER . '/' . PLUGIN_FOLDER; ?>/openstreetmap/leaflet.css" />
+			<link rel="stylesheet" type="text/css" href="<?php echo FULLWEBPATH . '/' . ZENFOLDER . '/' . PLUGIN_FOLDER; ?>/openstreetmap/MarkerCluster.css" />
+			<link rel="stylesheet" type="text/css" href="<?php echo FULLWEBPATH . '/' . ZENFOLDER . '/' . PLUGIN_FOLDER; ?>/openstreetmap/MarkerCluster.Default.css" />
 			<link rel="stylesheet" type="text/css" href="<?php echo FULLWEBPATH . '/' . ZENFOLDER . '/' . PLUGIN_FOLDER; ?>/openstreetmap/openstreetmap.css" />
 			<?php
 		}

--- a/zp-core/zp-extensions/openstreetmap/leaflet.css
+++ b/zp-core/zp-extensions/openstreetmap/leaflet.css
@@ -488,7 +488,6 @@ svg.leaflet-image-layer.leaflet-interactive path {
 	}
 .leaflet-popup-content p {
 	margin: 17px 0;
-	margin: 1.3em 0;
 	}
 .leaflet-popup-tip-container {
 	width: 40px;

--- a/zp-core/zp-extensions/openstreetmap/openstreetmap.css
+++ b/zp-core/zp-extensions/openstreetmap/openstreetmap.css
@@ -1,3 +1,3 @@
 .leaflet-popup-content{min-width:120px!important;max-width:120px!important;width:120px!important;}
-.leaflet-popup-content img{width:120px!important;height:auto;margin:10px 0;}
+.leaflet-popup-content img{height:auto;margin:10px 0;}
 .leaflet-popup-content,.leaflet-popup-content *{word-wrap:break-word;}

--- a/zp-core/zp-extensions/openstreetmap/openstreetmap.css
+++ b/zp-core/zp-extensions/openstreetmap/openstreetmap.css
@@ -1,3 +1,14 @@
-.leaflet-popup-content{min-width:120px!important;max-width:120px!important;width:120px!important;}
-.leaflet-popup-content img{height:auto;margin:10px 0;}
-.leaflet-popup-content,.leaflet-popup-content *{word-wrap:break-word;}
+.leaflet-popup-content {
+	min-width:120px!important;
+	max-width:120px!important;
+	width:120px!important;
+	}
+
+.leaflet-popup-content img {
+	height:auto;
+	margin:10px 0;
+	}
+
+.leaflet-popup-content,.leaflet-popup-content * {
+	word-wrap:break-word;
+	}


### PR DESCRIPTION
- Added missing `title` attributes to Image page links for markers on the map (title & thumb)
- Added classes for styling of title and thumbs for markers on the map (`openstreetmap-thumb`, `openstreetmap-title`)
- Added missing `alt` attribute to thumbs for markers on the map
- Removed trailing `<br>` after titles in thumbs (unnecessary, if need be - styling can be done with CSS now)
- Added option to specify `length` of title displayed for markers on the map.
- Added option to specify `length` of descriptions displayed for markers on the map.
- Added option to choose Default thumb or a Custom sized image to be displayed in markers on the map.
- Added option to specify the `width` of custom image, used as thumb.
- Changed default Custom image `width` to **120px** (to remove resizing of it's width by default CSS file)
- Removed `width` from default CSS file for images, to allow user to use smaller thumbs (with changed default size resizing via CSS is now unnecessary)
- Added option to disable usage of default CSS file, to allow for redesign of popup markers.
