### PR TITLE
Fix password match in registration form

### DIFF
--- a/zp-core/classes/class-authority.php
+++ b/zp-core/classes/class-authority.php
@@ -1235,7 +1235,7 @@ class Authority {
 				var inputa = '#pass' + id;
 				var inputb = '#pass_r' + id;
 				var display = '#match' + id;
-				if ($('#disclose_password' + id).prop('checked')) {
+				if (!$('#disclose_password' + id).prop('checked')) {
 					if ($(inputa).val() === $(inputb).val()) {
 						if ($(inputa).val().trim() !== '') {
 							$(display).css('color', '#008000');


### PR DESCRIPTION
Passwords are never marked as matching since the check is done when the confirmation field is hidden