### PR TITLE
Fixes for favoritesHandler extension

### DIFF
--- a/zp-core/template-functions.php
+++ b/zp-core/template-functions.php
@@ -476,7 +476,7 @@ function getHeadTitle($separator = ' | ', $listparentalbums = false, $listparent
 				if ($_zp_myfavorites->instance) {
 					$instance = ' [' . $_zp_myfavorites->instance . ']';
 				} 
-				$standard['favorites'] = gettext('My favorites') . $instance;
+				$standard['favorites'] = get_language_string(getOption('favorites_title')) . $instance;
 			}
 			if (array_key_exists($custompage, $standard)) {
 				return $standard[$custompage] . $pagenumber . $separator . $gallerytitle . $mainsitetitle;

--- a/zp-core/template-functions.php
+++ b/zp-core/template-functions.php
@@ -472,7 +472,11 @@ function getHeadTitle($separator = ' | ', $listparentalbums = false, $listparent
 					'archive' => gettext('Archive view'), 
 					'password' => gettext('Password required'));
 			if (is_object($_zp_myfavorites)) {
-				$standard['favorites'] = gettext('My favorites');
+				$instance = '';
+				if ($_zp_myfavorites->instance) {
+					$instance = ' [' . $_zp_myfavorites->instance . ']';
+				} 
+				$standard['favorites'] = gettext('My favorites') . $instance;
 			}
 			if (array_key_exists($custompage, $standard)) {
 				return $standard[$custompage] . $pagenumber . $separator . $gallerytitle . $mainsitetitle;

--- a/zp-core/zp-extensions/favoritesHandler.php
+++ b/zp-core/zp-extensions/favoritesHandler.php
@@ -278,6 +278,13 @@ if (OFFSET_PATH) {
 			$___Favorites = new favorites($_zp_current_admin_obj->getUser());
 			if (isset($_POST['instance']) && $_POST['instance']) {
 				$___Favorites->instance = trim(sanitize($_POST['instance']));
+				// Use an existing instance if the posted one differs only in uppercase or lowercase letters, since the instance options and tag_suggest suggestions are case-insensitive. 
+				foreach ($___Favorites->getList() as $value) {
+					if ($value && strtolower($value) === strtolower($___Favorites->instance)) {
+						$___Favorites->instance = $value;
+						break;
+					}
+				}
 				unset($_POST['instance']);
 			}
 			$id = sanitize($_POST['id']);
@@ -337,14 +344,15 @@ if (OFFSET_PATH) {
 				} else {
 					$list = array('');
 				}
-				if (extensionEnabled('tag_suggest') && !$_zp_myfavorites_button_count) {
+				$favList = array_slice($list, 1);
+				if (!empty($favList) && extensionEnabled('tag_suggest') && !$_zp_myfavorites_button_count) {
 					$_zp_myfavorites_button_count++;
-					$favList = array_slice($list, 1);
 					?>
 					<script>
 						var _favList = ['<?php echo implode("','", $favList); ?>'];
 						$(function() {
-							$('.favorite_instance').tagSuggest({tags: _favList})
+							var _favList = ['<?php echo implode("','", $favList); ?>'];
+							$('.favorite_instance').tagSuggest({tags: _favList});
 						});
 					</script>
 					<?php
@@ -409,10 +417,9 @@ if (OFFSET_PATH) {
 				if (is_null($text)) {
 					$text = get_language_string(getOption('favorites_linktext'));
 				}
-				$list = $_zp_myfavorites->getList();
 				$betwixt = NULL;
 				echo $before;
-				foreach ($_zp_myfavorites->getList()as $instance) {
+				foreach ($_zp_myfavorites->getList() as $instance) {
 					$link = $_zp_myfavorites->getLink(NULL, $instance);
 					$display = $text;
 					if ($instance) {

--- a/zp-core/zp-extensions/favoritesHandler/class-favorites.php
+++ b/zp-core/zp-extensions/favoritesHandler/class-favorites.php
@@ -57,11 +57,16 @@ class favorites extends AlbumBase {
 
 	function addImage($img) {
 		global $_zp_db;
-		$folder = $img->imagefolder;
-		$filename = $img->filename;
-		$sql = 'INSERT INTO ' . $_zp_db->prefix('plugin_storage') . ' (`type`, `aux`,`data`) VALUES ("favorites",' . $_zp_db->quote($this->getInstance()) . ',' . $_zp_db->quote(serialize(array('type' => 'images', 'id' => $folder . '/' . $filename))) . ')';
-		$_zp_db->query($sql);
-		zp_apply_filter('favoritesHandler_action', 'add', $img, $this->name);
+		$id = $img->imagefolder . "/" . $img->filename;
+		$table = $_zp_db->prefix('plugin_storage');
+		$aux = $_zp_db->quote($this->getInstance());
+		$data = $_zp_db->quote(serialize(array('type' => 'images', 'id' => $id)));
+		$record_exists = $_zp_db->querySingleRow('SELECT * FROM ' . $table . ' WHERE `type`="favorites" AND `aux`=' . $aux . ' AND `data`=' . $data);
+		if (!$record_exists) {
+			$sql = 'INSERT INTO ' . $table . ' (`type`, `aux`, `data`) VALUES ("favorites",' . $aux . ',' . $data . ')';
+			$_zp_db->query($sql);
+			zp_apply_filter('favoritesHandler_action', 'add', $img, $this->name);
+		}
 	}
 
 	function removeImage($img) {
@@ -75,10 +80,16 @@ class favorites extends AlbumBase {
 
 	function addAlbum($alb) {
 		global $_zp_db;
-		$folder = $alb->name;
-		$sql = 'INSERT INTO ' . $_zp_db->prefix('plugin_storage') . ' (`type`, `aux`,`data`) VALUES ("favorites",' . $_zp_db->quote($this->getInstance()) . ',' . $_zp_db->quote(serialize(array('type' => 'albums', 'id' => $folder))) . ')';
-		$_zp_db->query($sql);
-		zp_apply_filter('favoritesHandler_action', 'add', $alb, $this->name);
+		$id = $alb->name;
+		$table = $_zp_db->prefix('plugin_storage');
+		$aux = $_zp_db->quote($this->getInstance());
+		$data = $_zp_db->quote(serialize(array('type' => 'albums', 'id' => $id)));
+		$record_exists = $_zp_db->querySingleRow('SELECT * FROM ' . $table . ' WHERE `type`="favorites" AND `aux`=' . $aux . ' AND `data`=' . $data);
+		if (!$record_exists) {
+			$sql = 'INSERT INTO ' . $table . ' (`type`, `aux`, `data`) VALUES ("favorites",' . $aux . ',' . $data . ')';
+			$_zp_db->query($sql);
+			zp_apply_filter('favoritesHandler_action', 'add', $alb, $this->name);
+		}
 	}
 
 	function removeAlbum($alb) {
@@ -125,6 +136,9 @@ class favorites extends AlbumBase {
 					<ul class="userlist">
 						<?php
 						foreach ($watchers as $watchee) {
+							if ($serialized = @unserialize($watchee)) {
+								$watchee = $serialized[0] . "[" . $serialized[1] . "]";
+							}
 							?>
 							<li>
 								<?php echo html_encode($watchee); ?>
@@ -256,7 +270,7 @@ class favorites extends AlbumBase {
 		if ($_zp_myfavorites && isset($_REQUEST['instance'])) {
 			$_zp_myfavorites->instance = sanitize(rtrim($_REQUEST['instance'], '/'));
 			if ($_zp_myfavorites->instance)
-				$_zp_myfavorites->setTitle($_zp_myfavorites->getTitle() . '[' . $_zp_myfavorites->instance . ']');
+				$_zp_myfavorites->setTitle($_zp_myfavorites->getTitle() . ' [' . $_zp_myfavorites->instance . ']');
 		}
 		if ($_zp_gallery_page == "favorites.php") {
 			if (zp_loggedin()) {
@@ -272,7 +286,7 @@ class favorites extends AlbumBase {
 	}
 
 	static function pageCount($count, $gallery_page, $page) {
-		global $_zp_first_page_images, $_zp_one_image_page;
+		global $_zp_one_image_page;
 		if (stripSuffix($gallery_page) == 'favorites') {
 			$albums_per_page = max(1, getOption('albums_per_page'));
 			$pageCount = (int) ceil(getNumAlbums() / $albums_per_page);
@@ -285,11 +299,11 @@ class favorites extends AlbumBase {
 				}
 			}
 			$images_per_page = max(1, getOption('images_per_page'));
-			$count = ($pageCount + (int) ceil(($imageCount - $_zp_first_page_images) / $images_per_page));
+			$count = ($pageCount + (int) ceil(($imageCount - getFirstPageImages()) / $images_per_page));
 			if ($count < $page && isset($_POST['addToFavorites']) && !$_POST['addToFavorites']) {
-//We've deleted last item on page, need a place to land when we return
-				global $_zp_page;
-				redirectURL(FULLWEBPATH . '/' . $this->getLink($_zp_page - 1));
+				//We've deleted last item on page, need a place to land when we return
+				global $_zp_page, $_zp_myfavorites;
+				redirectURL(FULLWEBPATH . '/' . $_zp_myfavorites->getLink($_zp_page - 1));
 			}
 		}
 		return $count;
@@ -326,7 +340,7 @@ class favorites extends AlbumBase {
 			$tag = '_remove';
 		}
 		if ($instance && $multi) {
-			$add .= '[' . $instance . ']';
+			$add .= ' [' . $instance . ']';
 		}
 		?>
 		<form name="<?php echo $table . $obj->getID(); ?>Favorites_<?php echo $instance . $tag; ?>" class = "<?php echo $table; ?>Favorites<?php echo $tag; ?>"  action = "<?php echo html_encode(getRequestURI()); ?>" method = "post" accept-charset = "UTF-8">

--- a/zp-core/zp-extensions/favoritesHandler/class-favorites.php
+++ b/zp-core/zp-extensions/favoritesHandler/class-favorites.php
@@ -137,7 +137,7 @@ class favorites extends AlbumBase {
 						<?php
 						foreach ($watchers as $watchee) {
 							if ($serialized = @unserialize($watchee)) {
-								$watchee = $serialized[0] . "[" . $serialized[1] . "]";
+								$watchee = $serialized[0] . " [" . $serialized[1] . "]";
 							}
 							?>
 							<li>


### PR DESCRIPTION
As discussed here #1421
- Avoid duplicate instances of the same image/album
- Fix Users watching list in admin page
- Conform case letters of new instances to possibly existing ones, since instance options are case-insensitive
- Prevent tag_suggest bind code from output when not needed (i.e. most of the times)
- Fix page count and a wrong use of $this in the static function pageCount()
- Add instance name set to head title and use the text from the relevant option
