### PR TITLE
Replace deprecated HERE Map tile v2 with HERE raster tile service v3

### DIFF
--- a/zp-core/zp-extensions/openstreetmap.php
+++ b/zp-core/zp-extensions/openstreetmap.php
@@ -210,14 +210,16 @@ class openStreetMapOptions {
 						'key' => 'osmap_minimap_zoom',
 						'type' => OPTION_TYPE_TEXTBOX,
 						'desc' => gettext("The offset applied to the zoom in the minimap compared to the zoom of the main map. Can be positive or negative, defaults to -5.")),
-				gettext('HEREv3 - App id') => array(
-						'key' => 'osmap_HEREv3_appid',
+				gettext('HERE - ApiKey') => array(
+						'key' => 'osmap_here_apikey', //replaced deprecated appid with Apikey
 						'type' => OPTION_TYPE_TEXTBOX,
+						'order' => 22,
 						'desc' => ''),
-				gettext('HEREv3 - App code') => array(
-						'key' => 'osmap_HEREv3_appcode',
-						'type' => OPTION_TYPE_TEXTBOX,
-						'desc' => ''),
+			//	gettext('HERE - App code') => array(  App code is no longer needed
+			//			'key' => 'osmap_here_appcode',
+			//			'type' => OPTION_TYPE_TEXTBOX,
+			//			'order' => 23,
+			//			'desc' => ''),
 				gettext('Mapbox - Access token') => array(
 						'key' => 'osmap_mapbox_accesstoken',
 						'type' => OPTION_TYPE_TEXTBOX,
@@ -771,8 +773,8 @@ class openStreetMap {
 								. "})";
 			case 'HEREv3':
 				return "L.tileLayer.provider('" . $this->layer . "', {"
-								. "app_id: '" . getOption('osmap_HEREv3_appid') . "', "
-								. "app_code: '" . getOption('osmap_HEREv3_appcode') . "'"
+								. "app_id: '" . getOption('osmap_here_apikey') . "'" //replaced deprecatred appid with ApiKey
+								//. "app_code: '" . getOption('osmap_here_appcode') . "'" not required any more
 								. "})";
 			case 'Thunderforest':
 				return "L.tileLayer.provider('" . $this->layer . "', {"

--- a/zp-core/zp-extensions/openstreetmap/leaflet-providers.js
+++ b/zp-core/zp-extensions/openstreetmap/leaflet-providers.js
@@ -577,19 +577,22 @@
 			/*
 			 * HERE maps, formerly Nokia maps.
 			 * These basemaps are free, but you need an api id and app key. Please sign up at
-			 * https://developer.here.com/plans
+			 * https://platform.here.com/portal/
+			 * documentation at: https://www.here.com/docs/bundle/raster-tile-api-developer-guide/page/README.html
 			 */
 			url:
-				'https://{s}.{base}.maps.api.here.com/maptile/2.1/' +
-				'{type}/{mapID}/{variant}/{z}/{x}/{y}/{size}/{format}?' +
-				'app_id={app_id}&app_code={app_code}&lg={language}',
+				'https://maps.hereapi.com/v3/base/mc/'+ //new base url for HERE maptile v3 api
+			//	'https://{s}.{base}.maps.api.here.com/maptile/2.1/' + HERE will remove deprecated Maptile v2 soon
+				'{z}/{x}/{y}/{format}?style={variant}&size={size}' +
+				'&apiKey={app_id}&lg={language}',
 			options: {
 				attribution:
 					'Map &copy; 1987-' + new Date().getFullYear() + ' <a href="http://developer.here.com">HERE</a>',
 				subdomains: '1234',
 				mapID: 'newest',
-				'app_id': '<insert your app_id here>',
-				'app_code': '<insert your app_code here>',
+				/*'app_id': '<insert your app_id here>',*/
+				'app_id': '<insert your apiKey here>', 
+				//'app_code': '<insert your app_code here>', not required
 				base: 'base',
 				variant: 'normal.day',
 				maxZoom: 20,

--- a/zp-core/zp-extensions/openstreetmap/leaflet-providers.js
+++ b/zp-core/zp-extensions/openstreetmap/leaflet-providers.js
@@ -583,8 +583,8 @@
 			url:
 				'https://maps.hereapi.com/v3/base/mc/'+ //new base url for HERE maptile v3 api
 			//	'https://{s}.{base}.maps.api.here.com/maptile/2.1/' + HERE will remove deprecated Maptile v2 soon
-				'{z}/{x}/{y}/{format}?style={variant}&size={size}' +
-				'&apiKey={app_id}&lg={language}',
+				'{z}/{x}/{y}/{format}?style={variant}&size={size}' + //slightly modified parameters
+				'&apiKey={app_id}&lg={language}', //replacing app-id with apikey
 			options: {
 				attribution:
 					'Map &copy; 1987-' + new Date().getFullYear() + ' <a href="http://developer.here.com">HERE</a>',


### PR DESCRIPTION
Hey zenphoto dev team!

I highly appreciate your CMS since many years to publish my own little website!
To display my photos on the map I am using HERE map services. Unfortunately this has stopped working recently. The background is that HERE will remove its deprecated maptile service v2 very soon. This is replaced with HERE Raster tile api v3.

I created a fork with a modified osm plugin which includes the changes necessary to migrate to the new HERE raster tile api. This also switches from app-id and app-code to apikey.

I would highly appreciate if this change can be included in one of th upcoming official zenphoto releases! THX!

A few more background on HERE's apis:
Apikeys can be created for free at https://platform.here.com/portal/
Subscription remains for free, pricing details can be found here: https://www.here.com/get-started/pricing
Documentation for the HERE raster tile api can be found here:
https://www.here.com/docs/bundle/raster-tile-api-developer-guide/page/README.html