### PR TITLE
Removed unused use of deprecated method

### DIFF
--- a/zp-core/zp-extensions/html_meta_tags.php
+++ b/zp-core/zp-extensions/html_meta_tags.php
@@ -281,7 +281,6 @@ class htmlmetatags {
 		$canonicalurl = '';
 		// generate page title, get date
 		$pagetitle = ""; // for gallery index setup below switch
-		$date = zpFormattedDate(DATETIME_DISPLAYFORMAT); // if we don't have a item date use current date
 		$desc = getBareGalleryDesc();
 		$thumb = '';
 		$prev = $next = '';


### PR DESCRIPTION
This resolves the log warning:

> Parameter usage of zpFormattedDate (called from html_meta_tags.php line 284) is deprecated. It will be removed in Zenphoto 2.0.  Using strftime() based date formats strings is deprecated. Use standard date() compatible formatting or a timestamp instead. in functions/functions-basic.php on line 2269