### PR TITLE
Limit admin select inputs

### DIFF
--- a/zp-core/css/admin.css
+++ b/zp-core/css/admin.css
@@ -670,6 +670,10 @@ table.options tr td {
 	border: none;
 }
 
+table.options tr td select {
+	max-width: 300px;
+}
+
 table.formlayout {
 	width: 100%;
 }


### PR DESCRIPTION
This fixes a problem where long usernames force the Gallery tab to go off the page. For example on one of my sites plagued by spammers, the select box is 7947px wide 😆 
I made the CSS selector target all `select` inputs to anticipate similar problems