### PR TITLE
Update leaflet-providers.js for HERE map api

### DIFF
--- a/zp-core/zp-extensions/openstreetmap/leaflet-providers.js
+++ b/zp-core/zp-extensions/openstreetmap/leaflet-providers.js
@@ -616,7 +616,7 @@
 			url:
 				'https://maps.hereapi.com/v3/base/mc/' + // new base url for HERE maptile v3 api
 				'{z}/{x}/{y}/{format}?style={variant}&size={size}' + // slightly modified parameters
-				'&apiKey={app_id}&lg={language}', // replacing app-id with apikey
+			    '&apiKey={apiKey}&lg={language}', // replacing app-id with apikey
 			options: {
 				attribution:
 					'Map &copy; 1987-' + new Date().getFullYear() + ' <a href="http://platform.here.com">HERE</a>',


### PR DESCRIPTION
replacing app-id with apikey:
'&apiKey={apiKey}
the leaflet-providers.js repo has this already correct. apiKey is needed otherwise no map tiles will be displayed